### PR TITLE
fix : Added 'NTS_API_KEY' at github action workflow

### DIFF
--- a/.github/workflows/delpoy-dev.yml
+++ b/.github/workflows/delpoy-dev.yml
@@ -42,7 +42,7 @@ jobs:
             --ingress all \
             --allow-unauthenticated \
             --port 3000 \
-            --set-env-vars "NODE_ENV=development,NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}"
+            --set-env-vars "NODE_ENV=development,NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }},NTS_API_KEY=${{ secrets.NTS_API_KEY }}"
 
       - name: Send Discord Deployment Notification
         if: always()


### PR DESCRIPTION
## 💡 작업 내용

- [x] **NTS_API_KEY not configured**: dev 배포 워크플로우에 `NTS_API_KEY` 환경변수가 누락되어 추가

## 💡 자세한 설명                                                                       
  [Before] delpoy-dev.yml → NTS_API_KEY 미전달 → "NTS_API_KEY is not configured" (500)                                                                            
  [After]  delpoy-dev.yml → NTS_API_KEY 전달 

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

