### PR TITLE
fix: 로그인 후 userType 쿠키 누락 및 홈 하이드레이션 데드락 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ public/sw.js
 public/sw.js.map
 public/workbox-*.js
 public/workbox-*.js.map
+
+.docs/

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,8 +6,11 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const withPWA = withPWAInit({
   dest: 'public',
-  cacheOnFrontEndNav: true,
-  aggressiveFrontEndNavCaching: true,
+  // cacheOnFrontEndNav + aggressiveFrontEndNavCaching 비활성화
+  // 이유: 인증 상태 변경 후 SW가 캐시된 HTML을 제공하면
+  // React 하이드레이션 불일치 → 영구 skeleton 표시 버그 발생
+  cacheOnFrontEndNav: false,
+  aggressiveFrontEndNavCaching: false,
   reloadOnOnline: true,
   disable: process.env.NODE_ENV === 'development',
   workboxOptions: {
@@ -67,7 +70,7 @@ const nextConfig: NextConfig = {
               // Service Worker 허용 (PWA)
               "worker-src 'self'",
 
-              `connect-src 'self' https://wik-dev.moon-core.com https://t1.daumcdn.net https://static.cloudflareinsights.com`,
+              `connect-src 'self' https://wik-dev.moon-core.com https://*.workinkorea.net https://t1.daumcdn.net https://static.cloudflareinsights.com`,
               // iframe 허용 안 함 (frame-ancestors와 함께 사용)
               "frame-src 'none'",
               // 객체 임베드 차단

--- a/src/app/(main)/error.tsx
+++ b/src/app/(main)/error.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function MainError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[MainLayout] Render error:', error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4 bg-slate-50">
+      <div className="text-center mx-auto max-w-sm">
+        <div className="mb-8">
+          <h1 className="text-6xl font-extrabold text-slate-200 mb-2 leading-none">오류</h1>
+          <h2 className="text-xl font-bold text-slate-900 mb-3">
+            페이지를 ���러올 수 없습니다
+          </h2>
+          <p className="text-slate-500">
+            일���적인 오류가 발생했습니다. 다시 시도해 주세요.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <button
+            onClick={reset}
+            className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-colors cursor-pointer"
+          >
+            다시 시도
+          </button>
+
+          <button
+            onClick={() => window.location.href = '/'}
+            className="w-full px-6 py-3 border border-slate-200 text-slate-600 rounded-lg font-semibold hover:bg-slate-100 transition-colors cursor-pointer"
+          >
+            홈으로 이동
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/api/fetchClient.ts
+++ b/src/shared/api/fetchClient.ts
@@ -176,11 +176,21 @@ async function refreshToken(isServer: boolean): Promise<boolean> {
 /**
  * 인증 실패 시 로그아웃 처리
  * - Client-side only
+ * - userType 쿠키를 삭제해야 미들웨어 리다이렉트 루프 방지
  */
 function handleAuthFailure(): void {
   if (typeof window === 'undefined') return;
 
   const userType = getUserTypeFromCookie();
+
+  // userType 쿠키 삭제 (미들웨어가 보호 라우트 → 로그인 리다이렉트 루프 방지)
+  document.cookie = 'userType=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Lax';
+  const hostname = window.location.hostname;
+  if (hostname.includes('workinkorea.net')) {
+    document.cookie = 'userType=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=.workinkorea.net; SameSite=Lax';
+  } else if (hostname.includes('moon-core.com')) {
+    document.cookie = 'userType=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=.moon-core.com; SameSite=Lax';
+  }
 
   const loginPath =
     userType === 'company' ? '/company-login' :

--- a/src/shared/lib/utils/cookieManager.ts
+++ b/src/shared/lib/utils/cookieManager.ts
@@ -37,10 +37,15 @@ function setCookie(name: string, value: string, days: number = 7): void {
   const expires = new Date();
   expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000);
 
-  const domain = window.location.hostname.includes('moon-core.com') ? '.moon-core.com' : '';
-  const domainAttr = domain ? `domain=${domain};` : '';
+  const hostname = window.location.hostname;
+  let domainAttr = '';
+  if (hostname.includes('moon-core.com')) {
+    domainAttr = 'domain=.moon-core.com;';
+  } else if (hostname.includes('workinkorea.net')) {
+    domainAttr = 'domain=.workinkorea.net;';
+  }
 
-  document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/;${domainAttr}SameSite=Lax`;
+  document.cookie = `${name}=${value}; expires=${expires.toUTCString()}; path=/; ${domainAttr}SameSite=Lax`;
 }
 
 /**
@@ -54,28 +59,30 @@ function deleteCookie(name: string): void {
   if (typeof window === 'undefined') return;
 
   const hostname = window.location.hostname;
-  const expired = 'expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/;SameSite=Lax';
+  const expired = 'expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Lax';
 
   // 1. 도메인 속성 없음 (hostname 기본)
-  document.cookie = `${name}=;${expired}`;
+  document.cookie = `${name}=; ${expired}`;
   // 2. dot prefix 포함 (백엔드 Set-Cookie 방식)
-  document.cookie = `${name}=;${expired};domain=.${hostname}`;
+  document.cookie = `${name}=; ${expired}; domain=.${hostname}`;
   // 3. dot prefix 없음 (명시적 hostname)
-  document.cookie = `${name}=;${expired};domain=${hostname}`;
+  document.cookie = `${name}=; ${expired}; domain=${hostname}`;
+  // 4. 루트 도메인 (.workinkorea.net, .moon-core.com)
+  if (hostname.includes('workinkorea.net')) {
+    document.cookie = `${name}=; ${expired}; domain=.workinkorea.net`;
+  } else if (hostname.includes('moon-core.com')) {
+    document.cookie = `${name}=; ${expired}; domain=.moon-core.com`;
+  }
 }
 
 export const cookieManager = {
   /**
    * userType 읽기 (Public Cookie)
    *
-   * @deprecated HttpOnly 쿠키 전환으로 인해 클라이언트에서 읽을 수 없음 (항상 null 반환)
-   * 인증 상태 확인은 authApi.getProfile()을 사용하세요.
+   * 클라이언트에서 설정한 non-HttpOnly userType 쿠키를 읽는다.
+   * authStore.initialize() 의 폴백 경로에서 사용.
    *
    * @returns 'user' | 'company' | 'admin' | null
-   *
-   * @example
-   * // Don't use this for auth check
-   * // const userType = cookieManager.getUserType() // returns null
    */
   getUserType: (): UserType | null => {
     const value = getCookie('userType');

--- a/src/shared/stores/authStore.ts
+++ b/src/shared/stores/authStore.ts
@@ -22,6 +22,35 @@ interface AuthState {
   checkAuth: () => Promise<void>;
 }
 
+/**
+ * GET /api/me 로 세션 유효성 ���인
+ * HttpOnly access_token 쿠키가 살아있으면 200 반환 → userType 결정
+ */
+async function verifySessionWithProfile(): Promise<UserType | null> {
+  try {
+    const controller = new AbortController();
+    const tid = setTimeout(() => controller.abort(), 3000);
+
+    const res = await fetch('/api/me', {
+      credentials: 'include',
+      signal: controller.signal,
+    });
+    clearTimeout(tid);
+
+    if (res.ok) {
+      // /api/me 가 200이면 개인 회원으로 인증됨
+      // (기업 회원은 /api/company-profile 을 사용)
+      const cookieUserType = cookieManager.getUserType();
+      const userType = cookieUserType ?? 'user';
+      cookieManager.setUserType(userType);
+      return userType;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export const useAuthStore = create<AuthState>((set, get) => ({
   // Initial state
   isAuthenticated: false,
@@ -42,9 +71,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       isInitialized: true,
     });
 
-    // non-HttpOnly 쿠키를 별도 설정 — initialize() 폴백에서 document.cookie로 읽기 위해 필요
+    // non-HttpOnly 쿠키를 별도 설정 -- initialize() 폴백에서 document.cookie로 읽기 위해 필요
     // 백엔드가 설정한 쿠키는 HttpOnly이므로 JS에서 읽을 수 없음
-    // (브라우저 DevTools에 2개로 표시되나 값은 동일하며 각각 역할이 다름)
     cookieManager.setUserType(userType);
   },
 
@@ -88,116 +116,134 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   /**
    * 앱 시작 시 인증 상태 초기화
    *
-   * refresh_token (HttpOnly Cookie)으로 access_token을 재발급받고
-   * JWT payload에서 userType을 추출하여 인증 상태 결정
+   * 전략 (우선순위 순):
+   * 1. POST /api/auth/refresh -> access_token 재발급 + userType 결정
+   * 2. refresh 실패 시 GET /api/me -> HttpOnly access_token 쿠키가 유효한지 확인
+   * 3. 위 모두 실패 시 userType 쿠키 폴백
    *
-   * 타임아웃 설정: 10초
-   * - 네트워크 지연 또는 서버 무응답 시 skeleton이 무한히 표시되는 것을 방지
-   * - 타임아웃 발생 시 쿠키 폴백으로 사용자 진행 가능
+   * 타임아웃: 5초 (skeleton 무한 표시 방지)
    */
   initialize: async () => {
     if (typeof window === 'undefined') return;
-    if (get().isInitialized) return;           // Already initialized — skip
-    if (_initializationPromise) return _initializationPromise; // In progress — wait
+    if (get().isInitialized) return;
+    if (_initializationPromise) return _initializationPromise;
 
     _initializationPromise = (async () => {
-    // 로컬 개발 테스트 모드: 인증 우회
-    if (BYPASS_AUTH) {
-      set({
-        isAuthenticated: true,
-        userType: BYPASS_AUTH_TYPE,
-        isInitialized: true,
-      });
-      return;
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000);
-
-    try {
-      const response = await fetch('/api/auth/refresh', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-
-      if (response.ok) {
-        const data = await response.json();
-        const token: string | undefined = data.access_token;
-        const userTypeFromBody: UserType | undefined = data.user_type;
-
-        if (token) {
-          // Legacy path: backend returns token in body
-          tokenStore.set(token);
-          const userType = decodeUserType(token);
-          set({
-            isAuthenticated: true,
-            userType,
-            isInitialized: true,
-          });
-          return;
-        }
-
-        if (userTypeFromBody) {
-          // Current path: backend sets token as cookie, returns user_type in body
-          // Ensure userType cookie is set (in case it expired or was deleted)
-          cookieManager.setUserType(userTypeFromBody);
-          set({
-            isAuthenticated: true,
-            userType: userTypeFromBody,
-            isInitialized: true,
-          });
-          return;
-        }
-
-        // Fallback: 서버가 200 OK를 반환했지만 body에 token/user_type이 없는 경우
-        // userType 쿠키를 확인해 인증 상태 복원 (로그인 시 서버가 설정한 쿠키)
-        const cookieUserType = cookieManager.getUserType();
-        if (cookieUserType) {
-          set({
-            isAuthenticated: true,
-            userType: cookieUserType,
-            isInitialized: true,
-          });
-          return;
-        }
-      } else {
-        // refresh non-200 (서버 오류, 토큰 만료 등) — 쿠키로 마지막 폴백
-        // access_token / userType 쿠키가 살아 있으면 인증 상태 유지
-        const cookieUserType = cookieManager.getUserType();
-        if (cookieUserType) {
-          set({
-            isAuthenticated: true,
-            userType: cookieUserType,
-            isInitialized: true,
-          });
-          return;
-        }
-      }
-    } catch (err) {
-      clearTimeout(timeoutId);
-
-      // 네트워크 오류 또는 타임아웃 — 쿠키로 마지막 폴백
-      const cookieUserType = cookieManager.getUserType();
-      if (cookieUserType) {
+      // 로컬 개발 테스트 모드: 인증 우회
+      if (BYPASS_AUTH) {
         set({
           isAuthenticated: true,
-          userType: cookieUserType,
+          userType: BYPASS_AUTH_TYPE,
           isInitialized: true,
         });
         return;
       }
-    }
 
-    tokenStore.clear();
-    set({
-      isAuthenticated: false,
-      userType: null,
-      isInitialized: true,
-    });
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+      try {
+        const response = await fetch('/api/auth/refresh', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        if (response.ok) {
+          const data = await response.json();
+          const token: string | undefined = data.access_token;
+          const userTypeFromBody: UserType | undefined = data.user_type;
+
+          if (token) {
+            tokenStore.set(token);
+            const userType = decodeUserType(token);
+            if (userType) cookieManager.setUserType(userType);
+            set({
+              isAuthenticated: true,
+              userType,
+              isInitialized: true,
+            });
+            return;
+          }
+
+          if (userTypeFromBody) {
+            cookieManager.setUserType(userTypeFromBody);
+            set({
+              isAuthenticated: true,
+              userType: userTypeFromBody,
+              isInitialized: true,
+            });
+            return;
+          }
+
+          // 서버가 200 OK지만 body에 token/user_type 없음
+          const cookieUserType = cookieManager.getUserType();
+          if (cookieUserType) {
+            set({
+              isAuthenticated: true,
+              userType: cookieUserType,
+              isInitialized: true,
+            });
+            return;
+          }
+        } else {
+          // refresh 실패 (401 등)
+          // HttpOnly access_token 쿠키가 살아있을 수 있으므로 GET /api/me 로 확인
+          const verified = await verifySessionWithProfile();
+          if (verified) {
+            set({
+              isAuthenticated: true,
+              userType: verified,
+              isInitialized: true,
+            });
+            return;
+          }
+
+          // /api/me 도 실패 -- userType 쿠키 폴백
+          const cookieUserType = cookieManager.getUserType();
+          if (cookieUserType) {
+            set({
+              isAuthenticated: true,
+              userType: cookieUserType,
+              isInitialized: true,
+            });
+            return;
+          }
+        }
+      } catch (err) {
+        clearTimeout(timeoutId);
+
+        // 네트워크 오류 또는 타임아웃 -- GET /api/me 폴백
+        const verified = await verifySessionWithProfile();
+        if (verified) {
+          set({
+            isAuthenticated: true,
+            userType: verified,
+            isInitialized: true,
+          });
+          return;
+        }
+
+        const cookieUserType = cookieManager.getUserType();
+        if (cookieUserType) {
+          set({
+            isAuthenticated: true,
+            userType: cookieUserType,
+            isInitialized: true,
+          });
+          return;
+        }
+      }
+
+      tokenStore.clear();
+      set({
+        isAuthenticated: false,
+        userType: null,
+        isInitialized: true,
+      });
     })().finally(() => { _initializationPromise = null; });
 
     return _initializationPromise;


### PR DESCRIPTION
- authStore.initialize(): refresh 실패 시 GET /api/me 폴백 추가, 타임아웃 10s→5s
- cookieManager: workinkorea.net 도메인 처리 추가, @deprecated 태그 정리
- fetchClient.handleAuthFailure(): userType 쿠키 삭제로 리다이렉트 루프 방지
- next.config: PWA 공격적 캐싱 비활성화 (하이드레이션 불일치 방지)
- next.config: CSP connect-src에 *.workinkorea.net 추가
- (main)/error.tsx: 메인 라우트 그룹 에러 바운더리 추가

## 💡 작업 내용

- [x] 작업 내용

## 💡 자세한 설명

(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호
