### PR TITLE
fix: Critical 8 + 재테스트 리포트 29개 이슈 일괄 해결 

### DIFF
--- a/docs/design/component-specs.md
+++ b/docs/design/component-specs.md
@@ -10,21 +10,21 @@
 
 ```tsx
 interface ButtonProps {
-  variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger'
-  size?: 'sm' | 'md' | 'lg'
-  loading?: boolean
-  disabled?: boolean
-  children: React.ReactNode
+  variant?: "primary" | "secondary" | "outline" | "ghost" | "danger";
+  size?: "sm" | "md" | "lg";
+  loading?: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
 }
 ```
 
-| variant | 배경 | 텍스트 | 테두리 |
-|---------|------|--------|--------|
-| primary | blue-600 | white | — |
-| secondary | slate-100 | slate-800 | — |
-| outline | white | blue-600 | blue-600 |
-| ghost | transparent | slate-700 | — |
-| danger | red-500 | white | — |
+| variant   | 배경        | 텍스트    | 테두리   |
+| --------- | ----------- | --------- | -------- |
+| primary   | blue-600    | white     | —        |
+| secondary | slate-100   | slate-800 | —        |
+| outline   | white       | blue-600  | blue-600 |
+| ghost     | transparent | slate-700 | —        |
+| danger    | red-500     | white     | —        |
 
 ---
 
@@ -34,7 +34,7 @@ interface ButtonProps {
 
 ```tsx
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  error?: string
+  error?: string;
 }
 ```
 
@@ -50,10 +50,10 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 
 ```tsx
 interface FormFieldProps {
-  label: string
-  error?: string
-  required?: boolean
-  children: React.ReactNode
+  label: string;
+  error?: string;
+  required?: boolean;
+  children: React.ReactNode;
 }
 ```
 
@@ -65,11 +65,11 @@ interface FormFieldProps {
 
 ```tsx
 interface ModalProps {
-  isOpen: boolean
-  onClose: () => void
-  title?: string
-  size?: 'sm' | 'md' | 'lg' | 'full'
-  children: React.ReactNode
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  size?: "sm" | "md" | "lg" | "full";
+  children: React.ReactNode;
 }
 ```
 
@@ -85,23 +85,30 @@ interface ModalProps {
 
 ```tsx
 interface BadgeProps {
-  variant?: 'default' | 'success' | 'warning' | 'error' | 'info' | 'new' | 'deadline'
-  size?: 'sm' | 'md'
-  children: React.ReactNode
+  variant?:
+    | "default"
+    | "success"
+    | "warning"
+    | "error"
+    | "info"
+    | "new"
+    | "deadline";
+  size?: "sm" | "md";
+  children: React.ReactNode;
 }
 // 추가 컴포넌트
-NumericBadge   // 숫자 카운트 (알림 배지)
-DotBadge       // 상태 점 표시
-IndicatorBadge // 온라인/오프라인 인디케이터
+NumericBadge; // 숫자 카운트 (알림 배지)
+DotBadge; // 상태 점 표시
+IndicatorBadge; // 온라인/오프라인 인디케이터
 ```
 
-| variant | 배경 | 텍스트 |
-|---------|------|--------|
-| default | slate-100 | slate-700 |
-| success | green-50 | green-600 |
+| variant | 배경      | 텍스트     |
+| ------- | --------- | ---------- |
+| default | slate-100 | slate-700  |
+| success | green-50  | green-600  |
 | warning | yellow-50 | yellow-700 |
-| error | red-50 | red-600 |
-| info | blue-50 | blue-600 |
+| error   | red-50    | red-600    |
+| info    | blue-50   | blue-600   |
 
 ---
 
@@ -111,9 +118,9 @@ IndicatorBadge // 온라인/오프라인 인디케이터
 
 ```tsx
 interface SkeletonProps {
-  variant?: 'rect' | 'circle' | 'text'
-  className?: string
-  style?: React.CSSProperties
+  variant?: "rect" | "circle" | "text";
+  className?: string;
+  style?: React.CSSProperties;
 }
 ```
 
@@ -126,19 +133,19 @@ interface SkeletonProps {
 
 **용도**: 도메인별 로딩 스켈레톤
 
-| 컴포넌트 | 사용 위치 |
-|---------|---------|
-| `JobCardSkeleton` | 채용공고 목록 |
-| `JobListSkeleton` | 목록 전체 (6개) |
-| `JobDetailSkeleton` | 공고 상세 페이지 |
-| `UserProfileSkeleton` | 구직자 프로필 |
-| `CompanyDashboardSkeleton` | 기업 대시보드 |
-| `CompanyJobsSkeleton` | 기업 공고 목록 |
-| `TableSkeleton` | 관리자 테이블 |
-| `DiagnosisResultSkeleton` | 진단 결과 |
-| `FormPageSkeleton` | 폼 페이지 |
-| `DiagnosisSkeleton` | 진단 질문 |
-| `AdminDashboardSkeleton` | 관리자 대시보드 |
+| 컴포넌트                   | 사용 위치        |
+| -------------------------- | ---------------- |
+| `JobCardSkeleton`          | 채용공고 목록    |
+| `JobListSkeleton`          | 목록 전체 (6개)  |
+| `JobDetailSkeleton`        | 공고 상세 페이지 |
+| `UserProfileSkeleton`      | 구직자 프로필    |
+| `CompanyDashboardSkeleton` | 기업 대시보드    |
+| `CompanyJobsSkeleton`      | 기업 공고 목록   |
+| `TableSkeleton`            | 관리자 테이블    |
+| `DiagnosisResultSkeleton`  | 진단 결과        |
+| `FormPageSkeleton`         | 폼 페이지        |
+| `DiagnosisSkeleton`        | 진단 질문        |
+| `AdminDashboardSkeleton`   | 관리자 대시보드  |
 
 ---
 
@@ -148,21 +155,26 @@ interface SkeletonProps {
 
 ```tsx
 interface EmptyStateProps {
-  icon?: React.ReactNode
-  title: string
-  description?: string
-  action?: React.ReactNode
-  size?: 'sm' | 'md' | 'lg'
+  icon?: React.ReactNode;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  size?: "sm" | "md" | "lg";
 }
 ```
 
 사용 예:
+
 ```tsx
 <EmptyState
   icon={<SearchX className="w-12 h-12 text-slate-400" />}
   title="검색 결과가 없습니다"
   description="다른 검색어나 필터를 시도해보세요"
-  action={<Button variant="outline" onClick={resetFilters}>필터 초기화</Button>}
+  action={
+    <Button variant="outline" onClick={resetFilters}>
+      필터 초기화
+    </Button>
+  }
 />
 ```
 
@@ -174,9 +186,9 @@ interface EmptyStateProps {
 
 ```tsx
 interface LoadingSpinnerProps {
-  size?: 'sm' | 'md' | 'lg'
-  color?: 'blue' | 'white' | 'slate'
-  label?: string
+  size?: "sm" | "md" | "lg";
+  color?: "blue" | "white" | "slate";
+  label?: string;
 }
 ```
 
@@ -191,11 +203,11 @@ interface LoadingSpinnerProps {
 
 ```tsx
 interface StatCardProps {
-  label: string
-  value: string | number
-  icon?: React.ReactNode
-  trend?: { value: number; isPositive: boolean }
-  color?: 'blue' | 'green' | 'purple' | 'orange'
+  label: string;
+  value: string | number;
+  icon?: React.ReactNode;
+  trend?: { value: number; isPositive: boolean };
+  color?: "blue" | "green" | "purple" | "orange";
 }
 ```
 

--- a/docs/frontend-fix.md
+++ b/docs/frontend-fix.md
@@ -1,0 +1,197 @@
+# WorkInKorea 재테스트 리포트 — 2026-04-21
+
+> **테스터**: 장석원 (swj981128@gmail.com)  
+> **환경**: https://workinkorea.net (프로덕션)  
+> **방법**: Chrome MCP 직접 테스트 + API 레벨 검증  
+> **페르소나**: 비회원 → 개인회원(Google OAuth) → 기업회원(이메일)  
+> **이전 테스트**: 2026-04-20 ([[재테스트 리포트 2026-04-20]], [[재테스트 Addendum 2026-04-20]])  
+> **관련 문서**: [[WorkInKorea MOC]], [[이슈 목록 2026-04-21]]
+
+---
+
+## 🎯 한 줄 결론
+
+**서버 API는 거의 다 작동한다 — 프론트엔드가 막고 있다.**  
+기업/개인 모두의 **핵심 워크플로우(공고 등록, 지원하기, 이력서 저장, 프로필 로드)가 UI 레벨에서 깨져 있으며**, 서버 API는 직접 호출 시 200을 반환한다. 런치 전 반드시 **프론트엔드 단일 주간 스프린트**가 필요하다.
+
+---
+
+## 📊 심각도 요약 (총 29개 이슈)
+
+| 심각도       | 개수 | 대표 증상                                                                                           |
+| ------------ | ---- | --------------------------------------------------------------------------------------------------- |
+| **Critical** | 8    | 공고 등록 CTA 전원 무반응, 이력서 저장 422 silent 실패, /jobs SSR 에러, /user/profile 영구 스켈레톤 |
+| **High**     | 13   | 지원하기/북마크 무반응, `/user/resume/edit/{id}` 데이터 미로드, 기업명 "기업 #1" 하드코딩           |
+| **Medium**   | 6    | 진단 결과 100% 고정 의심, 로그인 상태 UI 미반영, refresh 401 루프                                   |
+| **Low**      | 2    | 헤더 KO/EN 대소문자 토글 혼용, 결과페이지 CTA 문구                                                  |
+
+---
+
+## 🔄 이전 테스트 대비 변경점
+
+### ✅ 고쳐진 이슈 (Regression 없음 확인)
+
+- **ISSUE-10/11 FIXED**: `/terms`, `/privacy` Markdown raw 노출 → HTML 정상 렌더링
+- **ISSUE-65 FIXED**: 급여 `3800` → `"3,800만원"` 정상
+- **기업 대시보드 FIXED**: 이전의 skeleton 영구 로딩 증상 해결 (렌더링 정상)
+- **/company/posts/create 초기 진입 개선**: 페이지 자체는 존재 (라우트 404 해결)
+
+### ❌ 여전히 깨진 이슈 (Persisting)
+
+- `/jobs` 페이지 SSR 에러 (`[JobsPage] Render error: Server Components render`)
+- 공고의 `start_date == end_date` → 전부 마감 표시
+- 페이지네이션 `limit=10` 파라미터 무시 (API가 전체 반환)
+- 로그인 직후 UI 상태 미반영 (5-10초 LCP 딜레이)
+
+### 🆕 새로 발견된 Critical (8개)
+
+1. 기업 **공고 등록 CTA 4개 전원 무반응** (새 등록 / 공고 등록 / 첫 공고 등록하기 / + 채용 공고 등록)
+2. 개인 **이력서 저장 422 + 에러 피드백 0** (서버는 빈 배열 거부, 클라이언트는 빈 배열 기본값 전송)
+3. 개인 **이력서 편집 폼 데이터 미로드** (`/user/resume/edit/{id}`에서 기존 값 prefill 안 됨)
+4. 개인 **/user/profile 영구 스켈레톤** (백그라운드 탭 hydration 실패)
+5. 개인 **`/api/me` 401 → refresh 401 20+회 루프** (tokenStore/쿠키 인증 방식 충돌)
+6. 기업 **대시보드 내 공고 카드 클릭 무반응** (상세/편집 진입 경로 없음)
+7. 개인 **지원하기 버튼 → /user/profile 리다이렉트** (지원 API 호출 없음)
+8. 기업 **`/company/posts/edit/{id}` 가드 오작동** (HEAD 200이지만 실제 이동 시 /company로 리턴)
+
+---
+
+## 🧪 테스트 커버리지
+
+### 비회원 (✅ 완료)
+
+- [x] 랜딩 페이지 렌더링
+- [x] 공고 목록(/jobs) SSR 에러 재현
+- [x] 공고 상세 (마감/활성 공고 각각)
+- [x] 회원가입/로그인 선택 페이지
+- [x] 약관/개보/고객센터/FAQ 정적 페이지 (모두 정상)
+- [x] EN 토글 동작 (부분 작동: 헤더만 번역)
+
+### 개인회원 (✅ 완료)
+
+- [x] Google OAuth 로그인 후 `/api/me` 200 (실 사용자 데이터)
+- [x] 자가진단 4 스텝 플로우 + 결과 페이지
+- [x] 이력서 생성 (POST /api/posts/resume)
+- [x] 이력서 수정 (API 레벨 PUT 성공)
+- [x] 프로필 편집 (`/user/profile/edit` 정상 작동)
+- [x] 지원하기 버튼 (무반응 확인)
+- [x] 북마크 버튼 (무반응 확인)
+
+### 기업회원 (✅ 완료)
+
+- [x] 이메일 로그인 후 대시보드 렌더
+- [x] 공고 등록 CTA 4개 전원 무반응 확인
+- [x] `/company/applicants` "준비 중"
+- [x] `/company/settings` "준비 중"
+- [x] 기업 프로필 편집(`/company/profile/edit`) 정상 prefill
+- [x] API 직접 호출로 공고 등록 성공(id=37) — UI 없이 백엔드는 작동
+- [x] 내 공고 카드 클릭 무반응
+
+---
+
+## 🔍 루트 원인 분석
+
+### 1. 인증 아키텍처 충돌 (Critical)
+
+**증거:**
+
+- 쿠키 탭 스크린샷: `access_token`, `refresh_token`, `userType` 모두 HttpOnly로 정상 발급
+- 하지만 `/api/me` 호출이 20+회 401 반복 후 겨우 200
+- `fetchClient`의 설계(CLAUDE.md): accessToken은 **in-memory tokenStore**로 관리
+
+**해석:**
+
+- 로그인 성공 시 서버가 HttpOnly 쿠키로 access_token을 발급하지만
+- 클라이언트 `fetchClient`는 여전히 `Authorization: Bearer <memory>` 헤더 방식만 사용
+- 따라서 페이지 새로고침 / 새 탭에서는 tokenStore가 비어있어 401 발생
+- `/api/auth/refresh`도 HttpOnly 쿠키 방식으로 전환된 것을 클라이언트가 따라가지 못함
+
+**권장:** `fetchClient.ts`에서 쿠키 기반 인증(`credentials: 'include'`)으로 통일하고 Authorization 헤더 로직 제거. 또는 서버에서 access_token은 cookie 발급을 중단하고 응답 body로만 내려보내기.
+
+### 2. 모달/네비게이션 트리거 미연결 (Critical)
+
+**증거:**
+
+- 기업 "새 채용 공고 등록" 등 4개 CTA `onclick` 속성은 존재하나 클릭 시 URL 변화 없음
+- 이력서 "저장하기"는 POST는 하지만 응답 처리 없음
+- 지원하기/북마크는 API 호출조차 없이 리다이렉트만
+
+**해석:**
+
+- 라우터 push / 모달 open 로직이 연결되지 않은 "dead button" 상태
+- 이벤트 핸들러가 등록되긴 했으나 실제 액션 분기(mutation + redirect)가 실행되지 않음
+
+**권장:** `CompanyDashboard`, `JobDetailApplyPanel`, `ResumeEditor`에서 이벤트 핸들러 전수 점검 필요.
+
+### 3. 서버 스키마 강제성 vs 클라이언트 기본값 불일치 (High)
+
+**증거:**
+
+- 이력서 POST 시 클라이언트가 `language_skills: [{language_type: "", level: ""}]` 같은 빈 객체 배열을 기본 전송
+- 서버는 `""` 값에 대해 422 반환
+- 최소 페이로드 `{title: "..."}`로는 200 정상
+
+**해석:**
+
+- react-hook-form / zod 스키마가 기본값으로 빈 객체 array를 채워 넣고, 사용자가 "추가" 버튼을 누르지 않아도 배열이 비어있지 않음
+- 서버의 Pydantic validation은 string min_length=1을 강제
+
+**권장:** 클라이언트 submit 전에 배열에서 모든 값이 빈 문자열인 항목을 필터링하거나, 서버 스키마를 Optional로 완화.
+
+### 4. Hydration 지연 (백그라운드 탭) (Medium)
+
+**증거:**
+
+- `/user/profile`, `/diagnosis` 페이지: `visibilityState: "hidden"` 상태에서 skeleton 100+개가 영구 표시
+- 사용자가 탭을 활성화하면 정상 렌더링
+
+**해석:** Next.js 16 App Router + React 19 hydration이 탭 visibility 에 영향을 받음 (requestIdleCallback 또는 visibility-aware lazy hydration 설정)
+
+**권장:** 주요 페이지는 eager hydration 처리 또는 visibilitychange 이벤트 핸들러 추가.
+
+---
+
+## 🎬 런치 차단 Top 10 (우선순위)
+
+1. **[CRITICAL]** 기업 공고 등록 CTA 무반응 4개 — 기업의 유일한 진입점
+2. **[CRITICAL]** 개인 이력서 저장 422 + 에러 피드백 0
+3. **[CRITICAL]** 지원하기 버튼 무반응 + `/api/applications` 미구현
+4. **[CRITICAL]** `/jobs` SSR Render error
+5. **[CRITICAL]** 이력서 편집 폼 데이터 미로드
+6. **[CRITICAL]** `/user/profile` 영구 스켈레톤
+7. **[CRITICAL]** `/api/me` → refresh 20+회 401 루프
+8. **[HIGH]** 기업명 "기업 #1" 하드코딩 + `"string"` 플레이스홀더 저장
+9. **[HIGH]** 공고 `start_date == end_date` 전원 마감 표시
+10. **[HIGH]** 북마크 기능 전체 미작동 (API 호출도 안 함)
+
+---
+
+## 📁 서버 상태 요약
+
+| 영역                         | 서버                            | 클라이언트                    |
+| ---------------------------- | ------------------------------- | ----------------------------- |
+| /api/me                      | ✅ 200 (데이터 정확)            | ❌ 401 루프 후 결국 200       |
+| /api/posts/company (POST)    | ✅ 200 (#37 생성)               | ❌ UI 버튼 무반응             |
+| /api/posts/company/list      | ✅ 200                          | ⚠️ limit 무시                 |
+| /api/posts/resume (POST)     | ✅ 200 (minimal) / 422 (빈배열) | ❌ 에러 피드백 0              |
+| /api/posts/resume/{id} (GET) | ✅ 200 (데이터 존재)            | ❌ 편집 페이지 prefill 안 함  |
+| /api/company-profile         | ✅ 200                          | ✅ /profile/edit prefill 정상 |
+| /api/diagnosis/answer        | ✅ 200                          | ✅ 플로우 작동                |
+| /api/applications/me         | ❌ 404 (미구현)                 | -                             |
+| /api/bookmarks               | ❌ 미확인 (UI 호출 안 함)       | ❌ 버튼 무반응                |
+| /api/auth/refresh            | ⚠️ 초기 401 반복 후 200         | ❌ 루프 재시도 무제한         |
+
+---
+
+## 🔗 관련 문서
+
+- [[이슈 목록 2026-04-21]] — 29개 이슈 GitHub 등록용 상세
+- [[WorkInKorea MOC]] — 전체 테스트 히스토리 허브
+- [[재테스트 리포트 2026-04-20]] — 하루 전 테스트 결과
+
+## 🧭 다음 단계
+
+1. 프론트엔드 팀: 이벤트 핸들러 연결 + tokenStore/쿠키 인증 통일 (Critical 8개)
+2. 백엔드 팀: `/api/applications`, `/api/bookmarks` 구현 (High)
+3. 디자인 QA: 기업 대시보드에 `"기업 #1"`, `"string"` 등 플레이스홀더 감추는 UI fallback (High)
+4. QA: Critical 해결 후 비회원→개인→기업 end-to-end 재검증 (`/apply → 지원 완료 → 기업이 지원자 확인`)

--- a/messages/en.json
+++ b/messages/en.json
@@ -87,7 +87,9 @@
       "privacy": "Privacy Policy",
       "terms": "Terms of Service",
       "faq": "FAQ",
-      "contact": "Contact Us"
+      "contact": "Contact Us",
+      "jobsLink": "Browse Jobs",
+      "supportLink": "Support Center"
     }
   },
   "landing": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -296,6 +296,7 @@
       "dashboardLabel": "Company Dashboard",
       "companyId": "Company #{id}",
       "companyFallback": "My Company",
+      "noCompanyInfo": "Company information isn't set yet. Please update it from Edit Profile.",
       "createPostBtn": "Post New Job",
       "tabPosts": "Active Postings",
       "tabProfile": "Company Info",

--- a/messages/en.json
+++ b/messages/en.json
@@ -117,7 +117,9 @@
       "stat3Label": "Successful Hires",
       "tagline": "Your Korean Career Starts Here",
       "loginPrompt": "Log in to see personalized job recommendations.",
-      "getStarted": "Get Started"
+      "welcomeBack": "Welcome back! Continue from your dashboard.",
+      "getStarted": "Get Started",
+      "goToDashboard": "Go to dashboard"
     },
     "services": {
       "overline": "Special Services",

--- a/messages/en.json
+++ b/messages/en.json
@@ -738,6 +738,11 @@
       "subtitle": "Manage your profile and view skill analysis",
       "errorTitle": "Unable to load profile",
       "errorSubtitle": "Please try again later.",
+      "loadingTimeout": {
+        "title": "Loading is taking too long",
+        "subtitle": "This can happen due to a slow network or a background tab restriction.",
+        "retry": "Try again"
+      },
       "tabs": {
         "overview": "Dashboard",
         "resume": "Resume",

--- a/messages/en.json
+++ b/messages/en.json
@@ -717,6 +717,23 @@
     }
   },
   "user": {
+    "bookmarks": {
+      "title": "Saved Jobs",
+      "subtitle": "You have {count} saved job(s)",
+      "emptyTitle": "No saved jobs yet",
+      "emptySubtitle": "Bookmark jobs you're interested in.",
+      "browseJobs": "Browse jobs"
+    },
+    "applications": {
+      "title": "My Applications",
+      "subtitle": "Review the jobs you've applied to",
+      "emptyTitle": "No applications yet",
+      "emptySubtitle": "Apply to jobs you're interested in.",
+      "notImplementedTitle": "Applications are coming soon",
+      "notImplementedSubtitle": "This will be available once the server is ready.",
+      "browseJobs": "Browse jobs",
+      "appliedOn": "Applied on {date}"
+    },
     "profile": {
       "title": "My Profile",
       "editProfile": "Edit Profile",

--- a/messages/en.json
+++ b/messages/en.json
@@ -293,6 +293,7 @@
     "dashboard": {
       "dashboardLabel": "Company Dashboard",
       "companyId": "Company #{id}",
+      "companyFallback": "My Company",
       "createPostBtn": "Post New Job",
       "tabPosts": "Active Postings",
       "tabProfile": "Company Info",

--- a/messages/en.json
+++ b/messages/en.json
@@ -229,6 +229,7 @@
       "expiredPost": "This position is closed",
       "expiredPostShort": "Position Closed",
       "applying": "Applying...",
+      "applied": "Applied",
       "bookmarkSaved": "Saved",
       "bookmarkSave": "Save Job",
       "modified": "Updated {date}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1382,6 +1382,7 @@
       "createError": "Failed to create resume.",
       "updateSuccess": "Resume updated successfully.",
       "updateError": "Failed to update resume.",
+      "validationError": "Please review your inputs. Some fields are invalid.",
       "imageTypeError": "Only image files can be uploaded.",
       "imageSizeError": "Image size must be 5MB or less.",
       "imageSuccess": "Image uploaded successfully.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1382,6 +1382,7 @@
       "createError": "이력서 생성에 실패했습니다.",
       "updateSuccess": "이력서가 수정되었습니다.",
       "updateError": "이력서 수정에 실패했습니다.",
+      "validationError": "입력값을 확인해주세요. 일부 항목이 올바르지 않습니다.",
       "imageTypeError": "이미지 파일만 업로드할 수 있습니다.",
       "imageSizeError": "이미지 크기는 5MB 이하여야 합니다.",
       "imageSuccess": "이미지가 업로드되었습니다.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -229,6 +229,7 @@
       "expiredPost": "마감된 공고입니다",
       "expiredPostShort": "마감된 공고",
       "applying": "지원 중...",
+      "applied": "지원 완료",
       "bookmarkSaved": "저장됨",
       "bookmarkSave": "북마크 저장",
       "modified": "{date} 수정",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -717,6 +717,23 @@
     }
   },
   "user": {
+    "bookmarks": {
+      "title": "북마크한 채용공고",
+      "subtitle": "{count}개의 공고를 저장했어요",
+      "emptyTitle": "저장된 공고가 없어요",
+      "emptySubtitle": "마음에 드는 공고에 북마크를 추가해 보세요.",
+      "browseJobs": "공고 둘러보기"
+    },
+    "applications": {
+      "title": "지원 내역",
+      "subtitle": "내가 지원한 공고를 확인해보세요",
+      "emptyTitle": "지원 내역이 없어요",
+      "emptySubtitle": "관심 있는 공고에 지원해 보세요.",
+      "notImplementedTitle": "지원 내역 기능 준비 중",
+      "notImplementedSubtitle": "서버 구현이 완료되는 대로 제공됩니다.",
+      "browseJobs": "공고 둘러보기",
+      "appliedOn": "{date} 지원"
+    },
     "profile": {
       "title": "내 프로필",
       "editProfile": "프로필 수정",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -738,6 +738,11 @@
       "subtitle": "프로필을 관리하고 스킬 분석을 확인하세요",
       "errorTitle": "프로필을 불러올 수 없습니다",
       "errorSubtitle": "잠시 후 다시 시도해주세요.",
+      "loadingTimeout": {
+        "title": "로딩이 지연되고 있어요",
+        "subtitle": "네트워크 상태 또는 백그라운드 탭 제약으로 응답이 지연될 수 있습니다.",
+        "retry": "다시 시도"
+      },
       "tabs": {
         "overview": "대시보드",
         "resume": "이력서",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -117,7 +117,9 @@
       "stat3Label": "취업 성공",
       "tagline": "한국 취업, 여기서 시작됩니다",
       "loginPrompt": "맞춤형 채용 공고 추천을 확인하려면 로그인하세요.",
-      "getStarted": "시작하기"
+      "welcomeBack": "다시 오신 것을 환영합니다. 대시보드에서 계속 진행해 보세요.",
+      "getStarted": "시작하기",
+      "goToDashboard": "대시보드로 이동"
     },
     "services": {
       "overline": "특별 서비스",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -293,6 +293,7 @@
     "dashboard": {
       "dashboardLabel": "기업 대시보드",
       "companyId": "기업 #{id}",
+      "companyFallback": "내 회사",
       "createPostBtn": "새 채용 공고 등록",
       "tabPosts": "관리 중인 공고",
       "tabProfile": "기업 정보",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -87,7 +87,9 @@
       "privacy": "개인정보처리방침",
       "terms": "이용약관",
       "faq": "자주 묻는 질문",
-      "contact": "문의하기"
+      "contact": "문의하기",
+      "jobsLink": "채용 공고 찾아보기",
+      "supportLink": "고객센터"
     }
   },
   "landing": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -296,6 +296,7 @@
       "dashboardLabel": "기업 대시보드",
       "companyId": "기업 #{id}",
       "companyFallback": "내 회사",
+      "noCompanyInfo": "기업 정보가 아직 입력되지 않았어요. 프로필 편집에서 설정해 주세요.",
       "createPostBtn": "새 채용 공고 등록",
       "tabPosts": "관리 중인 공고",
       "tabProfile": "기업 정보",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@storybook/react": "^10.3.5",
         "@storybook/test": "8.6.18",
         "@tailwindcss/postcss": "^4.1.12",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -5945,6 +5946,43 @@
         "@tanstack/react-query": "^5.90.20",
         "react": "^18 || ^19"
       }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@storybook/react": "^10.3.5",
     "@storybook/test": "8.6.18",
     "@tailwindcss/postcss": "^4.1.12",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/app/(main)/company/applicants/page.tsx
+++ b/src/app/(main)/company/applicants/page.tsx
@@ -1,18 +1,54 @@
 import { Metadata } from 'next';
+import Link from 'next/link';
+import { Users, Briefcase, Bell, Mail } from 'lucide-react';
 import { createMetadata } from '@/shared/lib/metadata';
-import { EmptyState } from '@/shared/ui/EmptyState';
 
 export const metadata: Metadata = createMetadata({
   title: '지원자 관리 - WorkInKorea',
   description: '채용 공고에 지원한 후보자들을 관리하세요.',
 });
 
+/**
+ * ISSUE-115: 서버 `/api/posts/company/{id}/applicants` 미구현.
+ * 단순 "준비 중" 대신 예정 기능 안내 + 대체 액션을 제공해 기업 회원이 길을 잃지 않도록 한다.
+ */
 export default function ApplicantsPage() {
   return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center py-12 px-4">
-      <div className="text-center max-w-md">
-        <h2 className="text-title-2 font-semibold text-slate-900 mb-2">준비 중입니다</h2>
-        <p className="text-body-2 text-slate-500">지원자 관리 기능은 곧 지원될 예정입니다</p>
+    <div className="min-h-screen bg-slate-50 py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-white rounded-xl border border-slate-200 p-8 sm:p-12 text-center">
+          <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-blue-50 flex items-center justify-center">
+            <Users className="w-8 h-8 text-blue-600" />
+          </div>
+          <h1 className="text-title-3 font-bold text-slate-900 mb-2">지원자 관리 기능 준비 중</h1>
+          <p className="text-body-3 text-slate-500 mb-8">
+            지원자 목록/열람/합격/불합격 처리는 서버 구현 완료 후 제공됩니다.
+          </p>
+
+          <div className="text-left bg-slate-50 rounded-lg p-4 mb-8">
+            <p className="text-caption-1 font-semibold text-slate-700 mb-2">예정된 기능</p>
+            <ul className="space-y-1.5 text-caption-2 text-slate-600">
+              <li className="flex items-center gap-2"><Briefcase size={13} className="text-slate-400" /> 공고별 지원자 목록</li>
+              <li className="flex items-center gap-2"><Mail size={13} className="text-slate-400" /> 이력서 열람 및 다운로드</li>
+              <li className="flex items-center gap-2"><Bell size={13} className="text-slate-400" /> 지원 단계별 상태 관리</li>
+            </ul>
+          </div>
+
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link
+              href="/company"
+              className="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg text-body-3 font-semibold hover:bg-blue-700 transition-colors"
+            >
+              대시보드로 돌아가기
+            </Link>
+            <Link
+              href="/company/jobs"
+              className="inline-flex items-center justify-center gap-2 px-5 py-2.5 border border-slate-200 text-slate-700 rounded-lg text-body-3 font-semibold hover:bg-slate-50 transition-colors"
+            >
+              공고 관리
+            </Link>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/app/(main)/company/profile/page.tsx
+++ b/src/app/(main)/company/profile/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * ISSUE-129: /company/profile 접근 시 편집 페이지로 리다이렉트.
+ * 별도 뷰 페이지가 없어 404 가 발생하던 문제를 해결한다.
+ * 추후 뷰 페이지가 생기면 이 파일을 대체한다.
+ */
+export default function CompanyProfilePage() {
+  redirect('/company/profile/edit');
+}

--- a/src/app/(main)/company/settings/page.tsx
+++ b/src/app/(main)/company/settings/page.tsx
@@ -1,4 +1,6 @@
 import { Metadata } from 'next';
+import Link from 'next/link';
+import { Settings, Key, Bell, CreditCard, User } from 'lucide-react';
 import { createMetadata } from '@/shared/lib/metadata';
 
 export const metadata: Metadata = createMetadata({
@@ -6,12 +8,56 @@ export const metadata: Metadata = createMetadata({
   description: '기업 계정 설정을 관리하세요.',
 });
 
+/**
+ * ISSUE-116: 현재 기업 설정 기능은 프로필 편집만 제공.
+ * 비밀번호 변경/알림 설정 등은 서버 구현 후 추가될 예정.
+ */
 export default function SettingsPage() {
   return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center py-12 px-4">
-      <div className="text-center max-w-md">
-        <h2 className="text-title-2 font-semibold text-slate-900 mb-2">준비 중입니다</h2>
-        <p className="text-body-2 text-slate-500">설정 기능은 곧 지원될 예정입니다</p>
+    <div className="min-h-screen bg-slate-50 py-12 px-4">
+      <div className="max-w-2xl mx-auto space-y-4">
+        <div className="bg-white rounded-xl border border-slate-200 p-6 sm:p-8">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-10 h-10 rounded-lg bg-blue-50 flex items-center justify-center">
+              <Settings size={20} className="text-blue-600" />
+            </div>
+            <div>
+              <h1 className="text-title-4 font-bold text-slate-900">기업 설정</h1>
+              <p className="text-caption-1 text-slate-500">계정 및 알림 설정을 관리합니다</p>
+            </div>
+          </div>
+          <Link
+            href="/company/profile/edit"
+            className="flex items-center justify-between px-4 py-3 border border-slate-200 rounded-lg hover:bg-slate-50 transition-colors"
+          >
+            <div className="flex items-center gap-3">
+              <User size={18} className="text-slate-500" />
+              <div>
+                <p className="text-body-3 font-semibold text-slate-900">기업 프로필 편집</p>
+                <p className="text-caption-2 text-slate-500">회사 정보, 연락처를 수정합니다</p>
+              </div>
+            </div>
+            <span className="text-caption-2 text-blue-600 font-semibold">이동 →</span>
+          </Link>
+        </div>
+
+        <div className="bg-white rounded-xl border border-slate-200 p-6 sm:p-8">
+          <p className="text-caption-1 font-semibold text-slate-700 mb-3">준비 중인 설정</p>
+          <ul className="space-y-3 text-caption-2 text-slate-500">
+            <li className="flex items-center gap-3 opacity-60">
+              <Key size={16} className="text-slate-400" />
+              <span>비밀번호 변경 (예정)</span>
+            </li>
+            <li className="flex items-center gap-3 opacity-60">
+              <Bell size={16} className="text-slate-400" />
+              <span>알림 설정 (예정)</span>
+            </li>
+            <li className="flex items-center gap-3 opacity-60">
+              <CreditCard size={16} className="text-slate-400" />
+              <span>결제/구독 관리 (예정)</span>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/src/app/(main)/user/applications/page.tsx
+++ b/src/app/(main)/user/applications/page.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from 'next';
+import { createMetadata } from '@/shared/lib/metadata';
+import UserApplicationsClient from '@/features/jobs/pages/UserApplicationsClient';
+
+export const metadata: Metadata = createMetadata({
+  title: '지원 내역 - WorkInKorea',
+  description: '내가 지원한 채용공고를 확인하세요.',
+});
+
+export default function UserApplicationsPage() {
+  return <UserApplicationsClient />;
+}

--- a/src/app/(main)/user/bookmarks/page.tsx
+++ b/src/app/(main)/user/bookmarks/page.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from 'next';
+import { createMetadata } from '@/shared/lib/metadata';
+import UserBookmarksClient from '@/features/jobs/pages/UserBookmarksClient';
+
+export const metadata: Metadata = createMetadata({
+  title: '북마크한 채용공고 - WorkInKorea',
+  description: '관심 있는 채용공고를 확인하세요.',
+});
+
+export default function UserBookmarksPage() {
+  return <UserBookmarksClient />;
+}

--- a/src/app/(main)/user/diagnosis/page.tsx
+++ b/src/app/(main)/user/diagnosis/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * ISSUE-110: /user/diagnosis 는 공개 자가진단 페이지로 리다이렉트.
+ */
+export default function UserDiagnosisPage() {
+  redirect('/diagnosis');
+}

--- a/src/app/(main)/user/resume/page.tsx
+++ b/src/app/(main)/user/resume/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * ISSUE-110: /user/resume 는 별도 목록 페이지가 없어 프로필 이력서 탭으로 리다이렉트.
+ */
+export default function UserResumePage() {
+  redirect('/user/profile?tab=resume');
+}

--- a/src/app/(main)/user/settings/page.tsx
+++ b/src/app/(main)/user/settings/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * ISSUE-110: /user/settings 는 프로필 편집 페이지(설정 섹션 포함)로 리다이렉트.
+ */
+export default function UserSettingsPage() {
+  redirect('/user/profile/edit');
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -107,7 +107,7 @@ export default function Loading() {
       </section>
 
       {/* CTA Section 스켈레톤 */}
-      <section className="bg-gradient-to-br from-primary-600 via-primary-700 to-primary-900 py-16 sm:py-20 lg:py-28">
+      <section className="bg-gradient-to-br from-blue-600 via-blue-700 to-blue-900 py-16 sm:py-20 lg:py-28">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center space-y-4 sm:space-y-5">
           <Skeleton className="h-10 sm:h-12 lg:h-14 w-40 sm:w-52 mx-auto bg-white/20" />
           <Skeleton variant="text" className="h-4 sm:h-5 w-56 sm:w-80 mx-auto bg-white/20" />

--- a/src/features/admin/components/EventsTableClient.tsx
+++ b/src/features/admin/components/EventsTableClient.tsx
@@ -16,8 +16,8 @@ function TypeBadge({ type }: { type: AdminEvent['type'] }) {
   const t = useTranslations('admin.events');
   const styles = {
     notice: 'bg-blue-100 text-blue-700',
-    event: 'bg-amber-500-bg text-amber-500',
-    promotion: 'bg-emerald-500-bg text-emerald-500',
+    event: 'bg-amber-50 text-amber-500',
+    promotion: 'bg-emerald-50 text-emerald-500',
   };
   const labels = {
     notice: t('typeBadgeNotice'),
@@ -34,7 +34,7 @@ function TypeBadge({ type }: { type: AdminEvent['type'] }) {
 function StatusBadge({ status }: { status: AdminEvent['status'] }) {
   const t = useTranslations('admin.events');
   return status === 'active' ? (
-    <span className="inline-flex items-center px-2.5 py-1 rounded-full text-caption-3 font-semibold bg-emerald-500-bg text-emerald-500">
+    <span className="inline-flex items-center px-2.5 py-1 rounded-full text-caption-3 font-semibold bg-emerald-50 text-emerald-500">
       {t('statusActive')}
     </span>
   ) : (
@@ -396,7 +396,7 @@ export function EventsTableClient({ initialData }: EventsTableClientProps) {
                         disabled={deleteMutation.isPending}
                         className={cn(
                           'px-3 py-1.5 text-caption-2 font-semibold rounded-lg transition-colors cursor-pointer',
-                          'bg-red-500-bg text-red-500 hover:bg-red-100',
+                          'bg-red-50 text-red-500 hover:bg-red-100',
                           'focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed',
                         )}
                       >

--- a/src/features/auth/components/BusinessLoginForm.tsx
+++ b/src/features/auth/components/BusinessLoginForm.tsx
@@ -211,7 +211,7 @@ export default function BusinessLoginForm() {
 
       {/* ── 좌측 그라데이션 패널 ──────────────────────────────────── */}
       <motion.div
-        className="hidden lg:flex flex-1 bg-linear-to-br from-primary-400 to-primary-600 flex-col justify-center p-16 relative overflow-hidden"
+        className="hidden lg:flex flex-1 bg-linear-to-br from-blue-400 to-blue-600 flex-col justify-center p-16 relative overflow-hidden"
         initial={{ opacity: 0, x: -24 }}
         animate={{ opacity: 1, x: 0 }}
         transition={{ duration: 0.5 }}
@@ -395,10 +395,10 @@ export default function BusinessLoginForm() {
                     loginError.type === 'network'
                       ? 'bg-slate-50 border border-slate-200 text-slate-600'
                       : loginError.type === 'server'
-                        ? 'bg-amber-500-bg border border-amber-200 text-amber-700'
+                        ? 'bg-amber-50 border border-amber-200 text-amber-700'
                         : loginError.type === 'rateLimit'
-                          ? 'bg-amber-500-bg border border-amber-200 text-amber-700'
-                          : 'bg-red-500-bg border border-red-500-bg text-red-500'
+                          ? 'bg-amber-50 border border-amber-200 text-amber-700'
+                          : 'bg-red-50 border border-red-200 text-red-500'
                   }`}
                   role="alert"
                   aria-live="polite"

--- a/src/features/auth/components/LoginContent.tsx
+++ b/src/features/auth/components/LoginContent.tsx
@@ -71,7 +71,7 @@ export default function LoginContent({ callbackUrl, error, signup }: LoginConten
     <div className="flex min-h-[calc(100vh-4rem)] flex-1">
       {/* 좌측 패널 - 데스크탑만 표시 */}
       <motion.div
-        className="hidden lg:flex flex-1 bg-linear-to-br from-primary-400 to-primary-600 flex-col justify-center items-center relative px-12 overflow-hidden"
+        className="hidden lg:flex flex-1 bg-linear-to-br from-blue-400 to-blue-600 flex-col justify-center items-center relative px-12 overflow-hidden"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.6 }}
@@ -168,7 +168,7 @@ export default function LoginContent({ callbackUrl, error, signup }: LoginConten
           {errorMessage && (
             <motion.div
               variants={itemVariants}
-              className="flex items-start gap-2.5 px-4 py-3 mb-6 rounded-lg bg-red-500-bg border border-red-500-bg text-caption-1 font-medium text-red-500"
+              className="flex items-start gap-2.5 px-4 py-3 mb-6 rounded-lg bg-red-50 border border-red-200 text-caption-1 font-medium text-red-500"
               role="alert"
               aria-live="polite"
             >

--- a/src/features/auth/components/LoginSelectContent.tsx
+++ b/src/features/auth/components/LoginSelectContent.tsx
@@ -94,7 +94,7 @@ export default function LoginSelectContent({ callbackUrl }: LoginSelectContentPr
                   transition={{ type: 'spring', stiffness: 300 }}
                 >
                   {/* 배경 그라데이션 (호버 시 표시) */}
-                  <div className="absolute inset-0 bg-linear-to-br from-primary-50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                  <div className="absolute inset-0 bg-linear-to-br from-blue-50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
 
                   <div className="relative z-10 flex flex-col h-full">
                     {/* 아이콘 */}

--- a/src/features/auth/components/SignupSelectContent.tsx
+++ b/src/features/auth/components/SignupSelectContent.tsx
@@ -47,7 +47,7 @@ export default function SignupSelectContent({ callbackUrl }: SignupSelectContent
   ] as const;
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-label-50 to-primary-50/30">
+    <div className="min-h-screen bg-linear-to-br from-label-50 to-blue-50/30">
       <div className="flex items-center justify-center px-4 py-8 sm:py-12 lg:py-16">
         <motion.div
           className="w-full max-w-3xl"
@@ -79,7 +79,7 @@ export default function SignupSelectContent({ callbackUrl }: SignupSelectContent
                 <Link href={href} className="block h-full">
                   <motion.div
                     className={cn(
-                      'bg-white rounded-2xl border-t-4 border-t-primary-600 border border-slate-200',
+                      'bg-white rounded-2xl border-t-4 border-t-blue-600 border border-slate-200',
                       'p-6 lg:p-8 min-h-[340px] sm:min-h-[360px] flex flex-col cursor-pointer',
                       'hover:border-blue-200 hover:shadow-lg transition-all duration-200'
                     )}

--- a/src/features/auth/pages/CompanyLoginClient.tsx
+++ b/src/features/auth/pages/CompanyLoginClient.tsx
@@ -7,7 +7,7 @@ function BusinessLoginSkeleton() {
   return (
     <div className="flex min-h-screen">
       {/* 좌측 패널 스켈레톤 */}
-      <div className="hidden lg:block flex-1 bg-linear-to-br from-primary-600 to-primary-900" />
+      <div className="hidden lg:block flex-1 bg-linear-to-br from-blue-600 to-blue-900" />
       {/* 우측 폼 스켈레톤 */}
       <div className="flex flex-1 flex-col justify-center px-8 sm:px-14 lg:px-20 py-12 bg-white">
         <div className="w-full max-w-[400px] mx-auto space-y-6">

--- a/src/features/company/pages/CompanyProfileClient.tsx
+++ b/src/features/company/pages/CompanyProfileClient.tsx
@@ -35,6 +35,19 @@ import { useAuth } from '@/features/auth/hooks/useAuth';
 import { toast } from 'sonner';
 import { isPostExpired } from '@/shared/lib/utils/formatDate';
 
+/**
+ * ISSUE-113: 서버에 저장된 "string" literal placeholder 값이 UI에 노출되는 것을 방지.
+ * 실제 정보처럼 보이지 않도록 필드를 렌더하지 않는다.
+ */
+function cleanPlaceholder(value: string | null | undefined): string {
+  if (!value) return '';
+  const trimmed = String(value).trim();
+  if (!trimmed) return '';
+  if (trimmed.toLowerCase() === 'string') return '';
+  if (/^0{2,}-0{2,}-\d+$/.test(trimmed)) return ''; // 010-0101-0101 같은 패턴
+  return trimmed;
+}
+
 type TodoTab = 'unread' | 'accepted' | 'interview' | 'evaluated';
 
 const CompanyProfileClient = () => {
@@ -528,33 +541,45 @@ const CompanyProfileClient = () => {
                     {t('editProfile')}
                   </button>
                 </div>
-                <div className="space-y-2">
-                  {profile.address && (
-                    <div className="flex items-start gap-2 text-caption-2 text-slate-500">
-                      <MapPin size={13} className="text-slate-300 mt-0.5 shrink-0" />
-                      <span className="leading-relaxed line-clamp-2">{profile.address}</span>
+                {(() => {
+                  const cleanAddress = cleanPlaceholder(profile.address);
+                  const cleanPhone = cleanPlaceholder(profile.phone_number);
+                  const cleanWebsite = cleanPlaceholder(profile.website_url);
+                  const hasAny = cleanAddress || cleanPhone || cleanWebsite;
+                  return hasAny ? (
+                    <div className="space-y-2">
+                      {cleanAddress && (
+                        <div className="flex items-start gap-2 text-caption-2 text-slate-500">
+                          <MapPin size={13} className="text-slate-300 mt-0.5 shrink-0" />
+                          <span className="leading-relaxed line-clamp-2">{cleanAddress}</span>
+                        </div>
+                      )}
+                      {cleanPhone && (
+                        <div className="flex items-center gap-2 text-caption-2 text-slate-500">
+                          <Phone size={13} className="text-slate-300 shrink-0" />
+                          <span>{cleanPhone}</span>
+                        </div>
+                      )}
+                      {cleanWebsite && (
+                        <div className="flex items-center gap-2 text-caption-2 text-slate-500">
+                          <Globe size={13} className="text-slate-300 shrink-0" />
+                          <a
+                            href={cleanWebsite}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 hover:underline truncate"
+                          >
+                            {cleanWebsite}
+                          </a>
+                        </div>
+                      )}
                     </div>
-                  )}
-                  {profile.phone_number && (
-                    <div className="flex items-center gap-2 text-caption-2 text-slate-500">
-                      <Phone size={13} className="text-slate-300 shrink-0" />
-                      <span>{profile.phone_number}</span>
-                    </div>
-                  )}
-                  {profile.website_url && (
-                    <div className="flex items-center gap-2 text-caption-2 text-slate-500">
-                      <Globe size={13} className="text-slate-300 shrink-0" />
-                      <a
-                        href={profile.website_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue-600 hover:underline truncate"
-                      >
-                        {profile.website_url}
-                      </a>
-                    </div>
-                  )}
-                </div>
+                  ) : (
+                    <p className="text-caption-2 text-slate-400">
+                      {t('noCompanyInfo')}
+                    </p>
+                  );
+                })()}
               </div>
 
               {/* 서비스 이용 현황 */}

--- a/src/features/company/pages/CompanyProfileClient.tsx
+++ b/src/features/company/pages/CompanyProfileClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -47,6 +47,16 @@ const CompanyProfileClient = () => {
       router.replace('/company', { scroll: false });
     }
   }, [searchParams, router]);
+
+  // 대시보드 내 모든 "공고 등록" CTA가 동일한 handler 를 사용하도록 통일.
+  // 이전에 일부 CTA 가 네비게이션을 트리거하지 못하던 이슈(ISSUE-101) 회귀 방지.
+  const handleCreateJob = useCallback(() => {
+    router.push('/company/posts/create');
+  }, [router]);
+
+  const handleManageJobs = useCallback(() => {
+    router.push('/company/jobs');
+  }, [router]);
 
   const [activeTodoTab, setActiveTodoTab] = useState<TodoTab>('unread');
 
@@ -172,7 +182,8 @@ const CompanyProfileClient = () => {
 
             <div className="flex items-center gap-2">
               <button
-                onClick={() => router.push('/company/jobs')}
+                type="button"
+                onClick={handleManageJobs}
                 className={cn(
                   'hidden sm:inline-flex items-center gap-1.5 px-4 py-2',
                   'border border-slate-200 rounded-lg text-caption-1 font-semibold text-slate-600',
@@ -183,7 +194,8 @@ const CompanyProfileClient = () => {
                 {t('manageJobs')}
               </button>
               <motion.button
-                onClick={() => router.push('/company/posts/create')}
+                type="button"
+                onClick={handleCreateJob}
                 className={cn(
                   'inline-flex items-center gap-1.5 px-4 py-2',
                   'bg-blue-600 text-white text-caption-1 font-semibold rounded-lg',
@@ -275,7 +287,8 @@ const CompanyProfileClient = () => {
                     <ChevronRight size={15} className="text-slate-300 group-hover:text-blue-400 transition-colors" />
                   </button>
                   <button
-                    onClick={() => router.push('/company/posts/create')}
+                    type="button"
+                    onClick={handleCreateJob}
                     className={cn(
                       'inline-flex items-center gap-1.5 px-3 py-1.5',
                       'bg-blue-600 text-white text-caption-2 font-semibold rounded-lg',
@@ -346,7 +359,8 @@ const CompanyProfileClient = () => {
                       </div>
                       <p className="text-caption-1 text-white0 mb-4">{t('noActivePosts')}</p>
                       <button
-                        onClick={() => router.push('/company/posts/create')}
+                        type="button"
+                        onClick={handleCreateJob}
                         className={cn(
                           'inline-flex items-center gap-1.5 px-4 py-2',
                           'bg-blue-600 text-white text-caption-1 font-semibold rounded-lg',
@@ -460,7 +474,8 @@ const CompanyProfileClient = () => {
                     채용 공고를 등록하고<br />최적의 후보자를 만나보세요
                   </p>
                   <button
-                    onClick={() => router.push('/company/posts/create')}
+                    type="button"
+                    onClick={handleCreateJob}
                     className={cn(
                       'w-full py-2 bg-white text-blue-700 text-caption-1 font-bold rounded-lg',
                       'hover:bg-blue-50 transition-colors cursor-pointer',

--- a/src/features/company/pages/CompanyProfileClient.tsx
+++ b/src/features/company/pages/CompanyProfileClient.tsx
@@ -33,6 +33,7 @@ import { postsApi } from '@/features/jobs/api/postsApi';
 import type { CompanyPost } from '@/shared/types/api';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { toast } from 'sonner';
+import { isPostExpired } from '@/shared/lib/utils/formatDate';
 
 type TodoTab = 'unread' | 'accepted' | 'interview' | 'evaluated';
 
@@ -106,9 +107,9 @@ const CompanyProfileClient = () => {
   }, [isError, error, router]);
 
   const posts: CompanyPost[] = postsData ?? [];
-  const now         = new Date();
-  const activePosts = posts.filter((p: CompanyPost) => new Date(p.end_date) > now);
-  const expiredPosts = posts.filter((p: CompanyPost) => new Date(p.end_date) <= now);
+  // start == end 시드 데이터는 마감으로 처리하지 않음 (ISSUE-114)
+  const activePosts = posts.filter((p: CompanyPost) => !isPostExpired(p.start_date, p.end_date));
+  const expiredPosts = posts.filter((p: CompanyPost) => isPostExpired(p.start_date, p.end_date));
 
   // ── 에러: 403 ─────────────────────────────────────────────────────────────
   if (isError && error instanceof FetchError && error.status === 403) {
@@ -315,7 +316,9 @@ const CompanyProfileClient = () => {
                     </div>
                   ) : activePosts.length > 0 ? (
                     activePosts.slice(0, 5).map(post => {
-                      const daysLeft = Math.ceil((new Date(post.end_date).getTime() - now.getTime()) / 86400000);
+                      const daysLeft = post.end_date
+                        ? Math.ceil((new Date(post.end_date).getTime() - Date.now()) / 86400000)
+                        : 0;
                       return (
                         <motion.button
                           key={post.id}

--- a/src/features/company/pages/CompanyProfileClient.tsx
+++ b/src/features/company/pages/CompanyProfileClient.tsx
@@ -443,13 +443,18 @@ const CompanyProfileClient = () => {
                   </div>
                   <div className="divide-y divide-slate-50">
                     {expiredPosts.slice(0, 3).map(post => (
-                      <div key={post.id} className="flex items-center gap-4 px-5 py-3 opacity-60">
+                      <button
+                        key={post.id}
+                        type="button"
+                        onClick={() => router.push(`/company/posts/edit/${post.id}`)}
+                        className="w-full flex items-center gap-4 px-5 py-3 opacity-60 hover:opacity-100 hover:bg-slate-50 transition text-left cursor-pointer"
+                      >
                         <div className="w-7 h-7 bg-slate-100 rounded-lg flex items-center justify-center shrink-0">
                           <FileText size={13} className="text-slate-400" />
                         </div>
                         <p className="text-caption-1 text-slate-600 truncate flex-1">{post.title}</p>
                         <span className="text-caption-3 text-slate-400 shrink-0">마감</span>
-                      </div>
+                      </button>
                     ))}
                   </div>
                 </div>

--- a/src/features/company/pages/CompanyProfileClient.tsx
+++ b/src/features/company/pages/CompanyProfileClient.tsx
@@ -117,7 +117,7 @@ const CompanyProfileClient = () => {
         <div className="min-h-screen bg-slate-100 flex items-center justify-center">
           <div className="bg-white rounded-xl border border-slate-200 p-8 text-center max-w-sm">
             <p className="text-slate-800 font-semibold mb-2">{t('accessDenied')}</p>
-            <p className="text-body-3 text-white0">{error.message}</p>
+            <p className="text-body-3 text-slate-500">{error.message}</p>
           </div>
         </div>
       </Layout>
@@ -227,14 +227,14 @@ const CompanyProfileClient = () => {
               },
               {
                 icon: <Users size={18} className="text-emerald-500" />,
-                bg: 'bg-emerald-500-bg',
+                bg: 'bg-emerald-50',
                 value: 0,
                 label: '전체 지원자',
                 action: undefined,
               },
               {
                 icon: <Bell size={18} className="text-amber-500" />,
-                bg: 'bg-amber-500-bg',
+                bg: 'bg-amber-50',
                 value: 0,
                 label: '미검토 지원',
                 action: undefined,
@@ -342,8 +342,8 @@ const CompanyProfileClient = () => {
                             <span className={cn(
                               'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-caption-3 font-semibold',
                               daysLeft <= 3
-                                ? 'bg-red-500-bg text-red-500'
-                                : 'bg-emerald-500-bg text-emerald-500',
+                                ? 'bg-red-50 text-red-500'
+                                : 'bg-emerald-50 text-emerald-500',
                             )}>
                               <Clock size={10} />
                               D-{daysLeft}
@@ -357,7 +357,7 @@ const CompanyProfileClient = () => {
                       <div className="w-12 h-12 bg-slate-100 rounded-full flex items-center justify-center mb-3">
                         <FileText size={22} className="text-slate-300" />
                       </div>
-                      <p className="text-caption-1 text-white0 mb-4">{t('noActivePosts')}</p>
+                      <p className="text-caption-1 text-slate-500 mb-4">{t('noActivePosts')}</p>
                       <button
                         type="button"
                         onClick={handleCreateJob}
@@ -402,7 +402,7 @@ const CompanyProfileClient = () => {
                         'flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-caption-2 font-semibold border transition-colors cursor-pointer',
                         activeTodoTab === tab.key
                           ? 'border-blue-500 bg-blue-50 text-blue-600'
-                          : 'border-slate-200 bg-white text-white0 hover:border-slate-200 hover:bg-slate-50',
+                          : 'border-slate-200 bg-white text-slate-500 hover:border-slate-200 hover:bg-slate-50',
                       )}
                     >
                       {tab.label}
@@ -465,7 +465,7 @@ const CompanyProfileClient = () => {
             <div className="space-y-4">
 
               {/* 채용공고 등록 CTA */}
-              <div className="bg-gradient-to-br from-primary-600 to-primary-800 rounded-xl p-5 relative overflow-hidden">
+              <div className="bg-gradient-to-br from-blue-600 to-blue-800 rounded-xl p-5 relative overflow-hidden">
                 <div className="absolute -top-4 -right-4 w-20 h-20 rounded-full bg-white/10" />
                 <div className="absolute bottom-2 -right-2 w-12 h-12 rounded-full bg-white/5" />
                 <div className="relative">
@@ -503,7 +503,7 @@ const CompanyProfileClient = () => {
                 <div className="p-4">
                   <div className="bg-blue-50 rounded-lg flex flex-col items-center py-5 text-center">
                     <Search size={20} className="text-blue-300 mb-2" />
-                    <p className="text-caption-2 text-white0 mb-3 leading-relaxed whitespace-pre-line">
+                    <p className="text-caption-2 text-slate-500 mb-3 leading-relaxed whitespace-pre-line">
                       {t('talentPoolCta')}
                     </p>
                     <button className="inline-flex items-center gap-1 text-caption-2 font-semibold text-blue-600 hover:underline transition-colors cursor-pointer">
@@ -527,19 +527,19 @@ const CompanyProfileClient = () => {
                 </div>
                 <div className="space-y-2">
                   {profile.address && (
-                    <div className="flex items-start gap-2 text-caption-2 text-white0">
+                    <div className="flex items-start gap-2 text-caption-2 text-slate-500">
                       <MapPin size={13} className="text-slate-300 mt-0.5 shrink-0" />
                       <span className="leading-relaxed line-clamp-2">{profile.address}</span>
                     </div>
                   )}
                   {profile.phone_number && (
-                    <div className="flex items-center gap-2 text-caption-2 text-white0">
+                    <div className="flex items-center gap-2 text-caption-2 text-slate-500">
                       <Phone size={13} className="text-slate-300 shrink-0" />
                       <span>{profile.phone_number}</span>
                     </div>
                   )}
                   {profile.website_url && (
-                    <div className="flex items-center gap-2 text-caption-2 text-white0">
+                    <div className="flex items-center gap-2 text-caption-2 text-slate-500">
                       <Globe size={13} className="text-slate-300 shrink-0" />
                       <a
                         href={profile.website_url}
@@ -567,13 +567,13 @@ const CompanyProfileClient = () => {
                     { icon: <Package  size={13} />, label: t('aptitude'),   status: '미이용' },
                   ].map(item => (
                     <div key={item.label} className="flex items-center justify-between px-4 py-3">
-                      <div className="flex items-center gap-2 text-caption-2 text-white0">
+                      <div className="flex items-center gap-2 text-caption-2 text-slate-500">
                         <span className="text-slate-300">{item.icon}</span>
                         {item.label}
                       </div>
                       <button className={cn(
                         'px-2.5 py-1 border border-slate-200 rounded',
-                        'text-caption-3 font-semibold text-white0 bg-white',
+                        'text-caption-3 font-semibold text-slate-500 bg-white',
                         'hover:bg-slate-50 transition-colors cursor-pointer',
                       )}>
                         {t('buyBtn')}
@@ -591,7 +591,7 @@ const CompanyProfileClient = () => {
                     {t('promoTitle')}
                   </p>
                 </div>
-                <p className="text-caption-2 text-white0 mb-3 leading-relaxed whitespace-pre-line">
+                <p className="text-caption-2 text-slate-500 mb-3 leading-relaxed whitespace-pre-line">
                   {t('promoSubtitle')}
                 </p>
                 <button className={cn(

--- a/src/features/company/pages/CompanyProfileClient.tsx
+++ b/src/features/company/pages/CompanyProfileClient.tsx
@@ -175,7 +175,7 @@ const CompanyProfileClient = () => {
                   {t('dashboardLabel')}
                 </p>
                 <h1 className="text-body-2 font-extrabold text-slate-900 truncate leading-tight">
-                  {t('companyId', { id: profile.company_id })}
+                  {profile.company_name || t('companyFallback')}
                 </h1>
               </div>
             </div>

--- a/src/features/company/validations/companyProfileValidation.ts
+++ b/src/features/company/validations/companyProfileValidation.ts
@@ -12,6 +12,14 @@ export type ValidationRule = (value: string | number, formData?: CompanyProfileR
 /**
  * Validation rules for company profile fields
  */
+/**
+ * ISSUE-113: 초기 시드/플레이스홀더 값 "string" 이 폼에 로드되었을 때 그대로 저장되는 것을 방지.
+ */
+function isPlaceholder(str: string): boolean {
+  const normalized = str.trim().toLowerCase();
+  return normalized === 'string' || normalized === 'null' || normalized === 'undefined';
+}
+
 export const companyProfileValidationRules: Record<string, ValidationRule> = {
   email: (value: string | number) => {
     const strValue = String(value);
@@ -46,18 +54,28 @@ export const companyProfileValidationRules: Record<string, ValidationRule> = {
   industry_type: (value: string | number) => {
     const strValue = String(value);
     if (!strValue || !strValue.trim()) return '업종을 입력해주세요.';
+    if (isPlaceholder(strValue)) return '업종을 정확히 입력해주세요.';
     return '';
   },
 
   company_type: (value: string | number) => {
     const strValue = String(value);
     if (!strValue || !strValue.trim()) return '기업 형태를 선택해주세요.';
+    if (isPlaceholder(strValue)) return '기업 형태를 정확히 선택해주세요.';
     return '';
   },
 
   address: (value: string | number) => {
     const strValue = String(value);
     if (!strValue || !strValue.trim()) return '주소를 입력해주세요.';
+    if (isPlaceholder(strValue)) return '주소를 정확히 입력해주세요.';
+    return '';
+  },
+
+  insurance: (value: string | number) => {
+    const strValue = String(value);
+    if (!strValue || !strValue.trim()) return '';
+    if (isPlaceholder(strValue)) return '보험 정보를 정확히 입력해주세요.';
     return '';
   },
 

--- a/src/features/diagnosis/components/RecommendedJobsSection.tsx
+++ b/src/features/diagnosis/components/RecommendedJobsSection.tsx
@@ -7,6 +7,7 @@ import { Briefcase, ArrowRight } from 'lucide-react';
 import { postsApi } from '@/features/jobs/api/postsApi';
 import JobCard from '@/features/jobs/components/JobCard';
 import { cn } from '@/shared/lib/utils/utils';
+import { isPostExpired } from '@/shared/lib/utils/formatDate';
 import type { DiagnosisData } from '@/features/diagnosis/store/diagnosisStore';
 import type { CompanyPost } from '@/shared/types/api';
 import { useTranslations } from 'next-intl';
@@ -25,9 +26,12 @@ export function RecommendedJobsSection({ diagnosisData }: RecommendedJobsSection
     retry: 1,
   });
 
-  // Filter by employmentType if available, then pick up to 4
+  // Filter: 활성 공고만 노출 (ISSUE-124 — 추천이 모두 마감으로 보이는 문제 방지)
+  // + employmentType 매칭 우선
   const jobs = (() => {
-    const posts = data?.company_posts ?? [];
+    const posts = (data?.company_posts ?? []).filter(
+      (p: CompanyPost) => !isPostExpired(p.start_date, p.end_date)
+    );
     if (!diagnosisData?.employmentType) return posts.slice(0, 4);
     const filtered = posts.filter(
       (p: CompanyPost) => p.employment_type === diagnosisData.employmentType

--- a/src/features/diagnosis/pages/DiagnosisResultClient.tsx
+++ b/src/features/diagnosis/pages/DiagnosisResultClient.tsx
@@ -43,7 +43,7 @@ const DiagnosisResultClient = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
   const { diagnosisId } = useDiagnosisStore();
   const [result, setResult] = useState<MatchingResult | null>(null);
   const [diagnosisData, setDiagnosisData] = useState<Partial<DiagnosisData> | null>(null);
@@ -387,8 +387,9 @@ const DiagnosisResultClient = () => {
             <p className="text-caption-1 sm:text-body-3 opacity-90 mb-6">
               {t('ctaSubtitle')}
             </p>
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              {!isAuthenticated ? (
+            {/* ISSUE-123: auth 초기화 이전에는 CTA 감추기 — 로그인 상태에서 회원가입 CTA 가 잠깐 보이는 현상 방지 */}
+            <div className="flex flex-col sm:flex-row gap-3 justify-center min-h-[46px]">
+              {authLoading ? null : !isAuthenticated ? (
                 <>
                   <motion.button
                     onClick={handleLogin}

--- a/src/features/diagnosis/pages/DiagnosisResultClient.tsx
+++ b/src/features/diagnosis/pages/DiagnosisResultClient.tsx
@@ -171,7 +171,7 @@ const DiagnosisResultClient = () => {
       <Layout>
         <div className="min-h-screen bg-white flex items-center justify-center px-4 py-8">
           <div className="text-center max-w-md">
-            <div className="inline-flex items-center justify-center w-16 h-16 bg-red-500-bg rounded-full mb-4">
+            <div className="inline-flex items-center justify-center w-16 h-16 bg-red-50 rounded-full mb-4">
               <AlertCircle className="text-red-500 w-8 h-8" />
             </div>
             <p className="text-body-1 text-slate-700 mb-2">{error}</p>
@@ -291,7 +291,7 @@ const DiagnosisResultClient = () => {
               )}
             >
               <div className="flex items-center gap-2.5 mb-4">
-                <div className="inline-flex items-center justify-center w-8 h-8 bg-emerald-500-bg rounded-lg">
+                <div className="inline-flex items-center justify-center w-8 h-8 bg-emerald-50 rounded-lg">
                   <CheckCircle className="text-emerald-500" size={20} />
                 </div>
                 <h2 className="text-body-1 sm:text-title-5 font-bold text-slate-900">{t('strengthsTitle')}</h2>
@@ -316,7 +316,7 @@ const DiagnosisResultClient = () => {
               )}
             >
               <div className="flex items-center gap-2.5 mb-4">
-                <div className="inline-flex items-center justify-center w-8 h-8 bg-amber-500-bg rounded-lg">
+                <div className="inline-flex items-center justify-center w-8 h-8 bg-amber-50 rounded-lg">
                   <AlertCircle className="text-amber-500" size={20} />
                 </div>
                 <h2 className="text-body-1 sm:text-title-5 font-bold text-slate-900">{t('improvementsTitle')}</h2>
@@ -376,7 +376,7 @@ const DiagnosisResultClient = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.5 }}
             className={cn(
-              'bg-linear-to-br from-primary-600 to-primary-800 rounded-2xl shadow-lg p-6 sm:p-8 lg:p-10',
+              'bg-linear-to-br from-blue-600 to-blue-800 rounded-2xl shadow-lg p-6 sm:p-8 lg:p-10',
               'text-center text-white mb-6'
             )}
           >

--- a/src/features/jobs/api/postsApi.ts
+++ b/src/features/jobs/api/postsApi.ts
@@ -205,10 +205,23 @@ export const postsApi = {
    * 채용 공고에 지원하기 (일반 사용자, 인증 필요)
    * @param data - 지원 정보 (company_post_id, resume_id, cover_letter)
    *
-   * TODO: 백엔드에 POST /api/applications 엔드포인트 구현 필요.
-   * 현재 해당 라우터가 존재하지 않아 404 에러 발생.
+   * 서버 404 시 "기능 준비 중" 메시지로 치환해 사용자에게 명확히 안내한다.
    */
-  async applyToJob(_data: ApplyToJobRequest): Promise<ApplyToJobResponse> {
-    throw new Error('지원 기능은 현재 준비 중입니다. 백엔드에 POST /api/applications 엔드포인트 구현이 필요합니다.');
+  async applyToJob(data: ApplyToJobRequest): Promise<ApplyToJobResponse> {
+    try {
+      return await fetchClient.post<ApplyToJobResponse>('/api/applications', data);
+    } catch (err) {
+      if (err instanceof FetchError && err.status === 404) {
+        throw new FetchError('지원 기능은 현재 준비 중입니다. 잠시 후 다시 시도해주세요.', 404);
+      }
+      throw err;
+    }
+  },
+
+  /**
+   * 내 지원 목록 조회
+   */
+  async getMyApplications(): Promise<{ applications: Array<{ id: number; post_id: number; resume_id: number; status: string; applied_at: string }> }> {
+    return fetchClient.get('/api/applications/me');
   },
 };

--- a/src/features/jobs/api/postsApi.ts
+++ b/src/features/jobs/api/postsApi.ts
@@ -1,5 +1,6 @@
 import { fetchClient, fetchAPI, FetchError } from '@/shared/api/fetchClient';
 import {
+  CompanyPost,
   CompanyPostsResponse,
   CreateCompanyPostRequest,
   CreateCompanyPostResponse,
@@ -44,6 +45,30 @@ interface RawCompanyPostsApiResponse {
  * - GET /api/posts/company/list?skip=&limit= 엔드포인트 서버에 없음
  * - 서버의 GET /api/posts/company/는 company auth 필요 (공개 아님)
  */
+/**
+ * CompanyPost 의 required string 필드가 null/undefined 로 내려오면 서버 컴포넌트 렌더에서
+ * `.split(',')`, `.toLowerCase()`, `new Date(null)` 파생값 등에서 예외가 발생한다.
+ * 타입 경계에서 안전한 기본값을 채워넣어 렌더 실패를 차단한다.
+ */
+function normalizeCompanyPost(raw: Partial<CompanyPost> & { id: number }): CompanyPost {
+  return {
+    id: raw.id,
+    company_id: raw.company_id ?? 0,
+    title: raw.title ?? '',
+    content: raw.content ?? '',
+    work_experience: raw.work_experience ?? '',
+    position_id: raw.position_id ?? 0,
+    education: raw.education ?? '',
+    language: raw.language ?? '',
+    employment_type: raw.employment_type ?? '',
+    work_location: raw.work_location ?? '',
+    working_hours: raw.working_hours ?? 0,
+    salary: raw.salary ?? 0,
+    start_date: raw.start_date ?? '',
+    end_date: raw.end_date ?? '',
+  };
+}
+
 export async function getCompanyPosts(
   page: number = DEFAULT_PAGE,
   limit: number = DEFAULT_LIMIT
@@ -63,7 +88,13 @@ export async function getCompanyPosts(
 
     // 래핑된 응답({ data: { company_posts } })과 일반 응답({ company_posts }) 모두 처리
     const inner = rawData.data ?? rawData;
-    const posts = inner.company_posts ?? [];
+    const rawPosts: unknown[] = Array.isArray(inner.company_posts) ? inner.company_posts : [];
+    // id 가 없는 row 는 key/라우팅에 쓸 수 없으므로 제외 + 나머지 필드는 안전한 기본값으로 정규화
+    const posts = rawPosts
+      .filter((p): p is Partial<CompanyPost> & { id: number } =>
+        !!p && typeof p === 'object' && typeof (p as { id?: unknown }).id === 'number'
+      )
+      .map(normalizeCompanyPost);
     const pagination = inner.pagination;
 
     // Pagination 계산
@@ -113,7 +144,12 @@ export const postsApi = {
 
     // 래핑된 응답({ data: { company_posts } })과 일반 응답({ company_posts }) 모두 처리
     const inner = rawData.data ?? rawData;
-    const posts = inner.company_posts ?? [];
+    const rawPosts: unknown[] = Array.isArray(inner.company_posts) ? inner.company_posts : [];
+    const posts = rawPosts
+      .filter((p): p is Partial<CompanyPost> & { id: number } =>
+        !!p && typeof p === 'object' && typeof (p as { id?: unknown }).id === 'number'
+      )
+      .map(normalizeCompanyPost);
     const pagination = inner.pagination;
 
     // Pagination 계산

--- a/src/features/jobs/components/CompanyPostForm.tsx
+++ b/src/features/jobs/components/CompanyPostForm.tsx
@@ -200,7 +200,7 @@ export function CompanyPostForm({
       className={cn(
         'inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold text-body-3',
         'border border-red-300 text-red-500',
-        'hover:bg-red-600-bg hover:border-red-400 transition-colors',
+        'hover:bg-red-50 hover:border-red-400 transition-colors',
         'disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer',
         'focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2',
       )}
@@ -334,7 +334,7 @@ export function CompanyPostForm({
               'inline-flex items-center gap-1.5 shrink-0',
               'px-4 py-2.5 rounded-lg font-semibold text-body-3',
               'border border-red-300 text-red-500',
-              'hover:bg-red-600-bg transition-colors',
+              'hover:bg-red-50 transition-colors',
               'disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer',
               'focus:outline-none',
             )}

--- a/src/features/jobs/components/JobCard.tsx
+++ b/src/features/jobs/components/JobCard.tsx
@@ -59,7 +59,7 @@ export default function JobCard({ post }: JobCardProps) {
           {/* Top Section: Icon + Type + Badges + Bookmark */}
           <div className="flex items-start gap-3 mb-4">
             {/* Company Icon */}
-            <div className="w-12 h-12 rounded-xl bg-linear-to-br from-primary-500 to-primary-700 flex items-center justify-center text-white shrink-0 shadow-sm">
+            <div className="w-12 h-12 rounded-xl bg-linear-to-br from-blue-500 to-blue-700 flex items-center justify-center text-white shrink-0 shadow-sm">
               <Building2 className="w-6 h-6" />
             </div>
 
@@ -74,7 +74,7 @@ export default function JobCard({ post }: JobCardProps) {
                 )}
                 {isUrgent && (
                   <motion.span
-                    className="inline-flex items-center px-2 py-0.5 bg-red-500-bg0 text-white text-caption-3 font-bold rounded-md"
+                    className="inline-flex items-center px-2 py-0.5 bg-red-500 text-white text-caption-3 font-bold rounded-md"
                     animate={{ opacity: [1, 0.6, 1] }}
                     transition={{ duration: 1.5, repeat: Infinity }}
                   >

--- a/src/features/jobs/components/JobCard.tsx
+++ b/src/features/jobs/components/JobCard.tsx
@@ -7,16 +7,11 @@ import { useBookmarks } from '@/features/jobs/hooks/useBookmarks';
 import { motion, useAnimation } from 'framer-motion';
 import { cn } from '@/shared/lib/utils/utils';
 import { formatSalary } from '@/shared/lib/utils/formatSalary';
+import { getDaysLeft, isPostExpired } from '@/shared/lib/utils/formatDate';
 import { useTranslations } from 'next-intl';
 
 interface JobCardProps {
   post: CompanyPost;
-}
-
-function getDaysLeft(endDate: string): number | null {
-  if (!endDate) return null;
-  const diff = new Date(endDate).getTime() - Date.now();
-  return Math.ceil(diff / (1000 * 60 * 60 * 24));
 }
 
 export default function JobCard({ post }: JobCardProps) {
@@ -25,10 +20,12 @@ export default function JobCard({ post }: JobCardProps) {
   const tCard = useTranslations('jobs.card');
   const tCommon = useTranslations('common');
 
-  const isRecent = new Date(post.start_date) > new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const startDateMs = post.start_date ? new Date(post.start_date).getTime() : NaN;
+  const isRecent = !isNaN(startDateMs) && startDateMs > Date.now() - 7 * 24 * 60 * 60 * 1000;
   const daysLeft = getDaysLeft(post.end_date);
   const isUrgent = daysLeft !== null && daysLeft >= 0 && daysLeft <= 3;
-  const isExpired = daysLeft !== null && daysLeft < 0;
+  // start == end 시드 데이터는 마감 처리하지 않음 (ISSUE-114)
+  const isExpired = isPostExpired(post.start_date, post.end_date);
   const language = post.language ? post.language.split(',').map(l => l.trim()) : [];
   const bookmarked = isBookmarked(post.id);
 

--- a/src/features/jobs/hooks/useJobApplication.ts
+++ b/src/features/jobs/hooks/useJobApplication.ts
@@ -1,6 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postsApi } from '@/features/jobs/api/postsApi';
 import type { ApplyToJobRequest } from '@/shared/types/api';
+import { FetchError } from '@/shared/api/fetchClient';
 import { toast } from 'sonner';
 
 /**
@@ -31,12 +32,21 @@ import { toast } from 'sonner';
  * ```
  */
 export function useJobApplication() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: (data: ApplyToJobRequest) => postsApi.applyToJob(data),
     onSuccess: () => {
       toast.success('지원이 완료되었습니다!');
+      queryClient.invalidateQueries({ queryKey: ['applications', 'me'] });
     },
     onError: (error: Error) => {
+      // 409 = 이미 지원한 공고
+      if (error instanceof FetchError && error.status === 409) {
+        toast.info('이미 지원한 공고입니다.');
+        queryClient.invalidateQueries({ queryKey: ['applications', 'me'] });
+        return;
+      }
       toast.error(error.message || '지원 중 오류가 발생했습니다. 다시 시도해주세요.');
     },
   });

--- a/src/features/jobs/pages/CompanyJobsClient.tsx
+++ b/src/features/jobs/pages/CompanyJobsClient.tsx
@@ -192,7 +192,7 @@ function CompanyJobsClient() {
                             {new Date(post.end_date) > new Date() ? (
                               <span className={cn(
                                 'inline-flex items-center px-2.5 py-1 rounded-full text-caption-3 font-semibold',
-                                'bg-emerald-500-bg text-emerald-500 border border-emerald-100'
+                                'bg-emerald-50 text-emerald-500 border border-emerald-100'
                               )}>
                                 {t('statusActive')}
                               </span>

--- a/src/features/jobs/pages/CompanyJobsClient.tsx
+++ b/src/features/jobs/pages/CompanyJobsClient.tsx
@@ -12,6 +12,7 @@ import type { CompanyPost } from '@/shared/types/api';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { cn } from '@/shared/lib/utils/utils';
 import { formatSalary } from '@/shared/lib/utils/formatSalary';
+import { formatDateRange, isPostExpired } from '@/shared/lib/utils/formatDate';
 
 function CompanyJobsClient() {
   const t = useTranslations('jobs.manage');
@@ -185,11 +186,11 @@ function CompanyJobsClient() {
                               {formatSalary(post.salary, t('negotiable'))}
                             </p>
                             <p className="text-caption-2 text-slate-400">
-                              {post.start_date} ~ {post.end_date}
+                              {formatDateRange(post.start_date, post.end_date)}
                             </p>
                           </div>
                           <div className="flex items-center gap-2">
-                            {new Date(post.end_date) > new Date() ? (
+                            {!isPostExpired(post.start_date, post.end_date) ? (
                               <span className={cn(
                                 'inline-flex items-center px-2.5 py-1 rounded-full text-caption-3 font-semibold',
                                 'bg-emerald-50 text-emerald-500 border border-emerald-100'

--- a/src/features/jobs/pages/CompanyJobsClient.tsx
+++ b/src/features/jobs/pages/CompanyJobsClient.tsx
@@ -151,9 +151,19 @@ function CompanyJobsClient() {
                       initial={{ opacity: 0, y: 10 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ duration: 0.3 }}
+                      onClick={() => router.push(`/company/posts/edit/${post.id}`)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          router.push(`/company/posts/edit/${post.id}`);
+                        }
+                      }}
+                      role="button"
+                      tabIndex={0}
                       className={cn(
                         'bg-white border border-slate-200 rounded-xl p-4 sm:p-6 shadow-sm',
-                        'hover:border-blue-200 hover:shadow-md transition-all duration-200 cursor-pointer'
+                        'hover:border-blue-200 hover:shadow-md transition-all duration-200 cursor-pointer',
+                        'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2'
                       )}
                     >
                       <div className="flex items-start justify-between gap-3">
@@ -197,7 +207,11 @@ function CompanyJobsClient() {
                           </div>
                         </div>
                         <motion.button
-                          onClick={() => router.push(`/company/posts/edit/${post.id}`)}
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            router.push(`/company/posts/edit/${post.id}`);
+                          }}
                           className={cn(
                             'p-2 text-slate-400 hover:text-blue-600 hover:bg-blue-50 transition-colors duration-150',
                             'rounded-lg shrink-0 focus:outline-none cursor-pointer'

--- a/src/features/jobs/pages/CompanyPostEditClient.tsx
+++ b/src/features/jobs/pages/CompanyPostEditClient.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from 'next-intl';
 import Layout from '@/shared/components/layout/Layout';
 import { Button } from '@/shared/ui/Button';
 import { useAuth } from '@/features/auth/hooks/useAuth';
+import { cookieManager } from '@/shared/lib/utils/cookieManager';
 import { postsApi } from '@/features/jobs/api/postsApi';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { UpdateCompanyPostRequest } from '@/shared/types/api';
@@ -26,18 +27,27 @@ function CompanyPostEditClient({ postId }: CompanyPostEditClientProps) {
   const queryClient = useQueryClient();
   const { isAuthenticated, isLoading: authLoading, userType } = useAuth();
 
-  // 인증 완료 후 권한 체크 — 비인증 또는 기업 회원이 아닌 경우 로그인 페이지로 리다이렉트
+  // 인증 완료 후 권한 체크 — 비인증 또는 기업 회원이 아닌 경우 로그인 페이지로 리다이렉트.
+  // ISSUE-117: authStore 초기화가 실패(refresh 401 등)해도 userType 쿠키가 'company' 면
+  // 미들웨어는 통과시켜 주는데 client 측에서 /company 로 리턴해버리던 문제 수정.
+  // 쿠키 fallback 으로 실제 userType 을 확인하여 불필요한 redirect 를 방지.
   useEffect(() => {
-    if (!authLoading && (!isAuthenticated || userType !== 'company')) {
+    if (authLoading) return;
+    const effectiveUserType = userType ?? cookieManager.getUserType();
+    if (!effectiveUserType) {
+      router.replace('/company-login');
+      return;
+    }
+    if (effectiveUserType !== 'company') {
       router.replace('/company-login');
     }
   }, [authLoading, isAuthenticated, userType, router]);
 
-  // 공고 데이터 로드
+  // 공고 데이터 로드 — userType 쿠키 fallback 허용
   const { data: post, isLoading: postLoading } = useQuery({
     queryKey: ['companyPost', postId],
     queryFn: () => postsApi.getCompanyPostById(Number(postId)),
-    enabled: !!postId && isAuthenticated && userType === 'company',
+    enabled: !!postId && !authLoading && (userType === 'company' || cookieManager.getUserType() === 'company'),
     retry: false,
   });
 

--- a/src/features/jobs/pages/CompanyPostEditClient.tsx
+++ b/src/features/jobs/pages/CompanyPostEditClient.tsx
@@ -228,7 +228,7 @@ function CompanyPostEditClient({ postId }: CompanyPostEditClientProps) {
               <Button
                 type="button"
                 size="lg"
-                className="w-full border border-red-500-bg text-red-500 hover:bg-red-600-bg bg-white"
+                className="w-full border border-red-200 text-red-500 hover:bg-red-50 bg-white"
                 onClick={handleDelete}
                 disabled={deletePostMutation.isPending}
               >

--- a/src/features/jobs/pages/JobDetailView.tsx
+++ b/src/features/jobs/pages/JobDetailView.tsx
@@ -278,7 +278,7 @@ export default function JobDetailView({ job, jobId }: JobDetailViewProps) {
                   <div className="flex items-start gap-4 justify-between">
                     <div className="flex items-start gap-4 flex-1 min-w-0">
                       {/* Company Icon */}
-                      <div className="w-16 h-16 sm:w-20 sm:h-20 bg-linear-to-br from-primary-500 to-primary-700 rounded-xl flex items-center justify-center text-white shrink-0 shadow-sm">
+                      <div className="w-16 h-16 sm:w-20 sm:h-20 bg-linear-to-br from-blue-500 to-blue-700 rounded-xl flex items-center justify-center text-white shrink-0 shadow-sm">
                         <Building2 className="w-8 h-8 sm:w-10 sm:h-10" />
                       </div>
 
@@ -289,7 +289,7 @@ export default function JobDetailView({ job, jobId }: JobDetailViewProps) {
                         <div className="flex items-center gap-2 mb-3 flex-wrap">
                           {isUrgent && (
                             <motion.span
-                              className="inline-flex items-center px-2 py-0.5 bg-red-500-bg0 text-white text-caption-3 font-bold rounded-md"
+                              className="inline-flex items-center px-2 py-0.5 bg-red-500 text-white text-caption-3 font-bold rounded-md"
                               animate={{ opacity: [1, 0.6, 1] }}
                               transition={{ duration: 1.5, repeat: Infinity }}
                             >
@@ -354,7 +354,7 @@ export default function JobDetailView({ job, jobId }: JobDetailViewProps) {
                   </div>
 
                   {/* Recruitment Period */}
-                  <div className="flex items-center gap-3 p-4 bg-amber-500-bg border border-amber-100 rounded-lg">
+                  <div className="flex items-center gap-3 p-4 bg-amber-50 border border-amber-100 rounded-lg">
                     <Calendar className="text-amber-500 shrink-0" size={18} />
                     <p className="text-caption-1 text-slate-900">
                       <span className="font-semibold">{t('recruitPeriod')}:</span> {effectiveJob.start_date} ~ {effectiveJob.end_date}

--- a/src/features/jobs/pages/JobDetailView.tsx
+++ b/src/features/jobs/pages/JobDetailView.tsx
@@ -35,7 +35,7 @@ export default function JobDetailView({ job, jobId }: JobDetailViewProps) {
   const router = useRouter();
   const pathname = usePathname();
   const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
-  const { mutate: applyToJob, isPending } = useJobApplication();
+  const { mutate: applyToJob, isPending, isSuccess: hasJustApplied } = useJobApplication();
   const { toggle, isBookmarked } = useBookmarks();
   const [showApplyModal, setShowApplyModal] = useState(false);
   const [selectedResumeId, setSelectedResumeId] = useState<number | null>(null);
@@ -243,10 +243,15 @@ export default function JobDetailView({ job, jobId }: JobDetailViewProps) {
         <div className="fixed bottom-6 left-0 right-0 px-4 z-40 lg:hidden">
           <motion.button
             onClick={handleApply}
-            whileTap={{ scale: 0.97 }}
-            className="w-full bg-blue-600 hover:bg-blue-700 text-white py-3.5 rounded-xl font-bold text-body-2 shadow-[0_4px_14px_rgba(66,90,213,0.25)] transition-colors cursor-pointer"
+            disabled={hasJustApplied}
+            whileTap={{ scale: hasJustApplied ? 1 : 0.97 }}
+            className={
+              hasJustApplied
+                ? "w-full bg-slate-200 text-slate-500 py-3.5 rounded-xl font-bold text-body-2 cursor-not-allowed"
+                : "w-full bg-blue-600 hover:bg-blue-700 text-white py-3.5 rounded-xl font-bold text-body-2 shadow-[0_4px_14px_rgba(66,90,213,0.25)] transition-colors cursor-pointer"
+            }
           >
-            {tCommon('button.apply')}
+            {hasJustApplied ? t('applied') : tCommon('button.apply')}
           </motion.button>
         </div>
       )}
@@ -438,6 +443,13 @@ export default function JobDetailView({ job, jobId }: JobDetailViewProps) {
                 {isExpired ? (
                   <button className="w-full py-4 bg-slate-100 text-slate-400 text-center rounded-lg font-bold text-body-2 cursor-not-allowed">
                     {t('expiredPostShort')}
+                  </button>
+                ) : hasJustApplied ? (
+                  <button
+                    disabled
+                    className="w-full py-4 bg-slate-200 text-slate-500 rounded-lg font-bold text-body-2 cursor-not-allowed"
+                  >
+                    {t('applied')}
                   </button>
                 ) : (
                   <motion.button

--- a/src/features/jobs/pages/JobDetailView.tsx
+++ b/src/features/jobs/pages/JobDetailView.tsx
@@ -17,15 +17,11 @@ import { resumeApi } from '@/features/resume/api/resumeApi';
 import { postsApi } from '@/features/jobs/api/postsApi';
 import type { CompanyPostDetailResponse } from '@/shared/types/api';
 import { formatSalary } from '@/shared/lib/utils/formatSalary';
+import { formatDateRange, formatDateShort, isPostExpired, getDaysLeft } from '@/shared/lib/utils/formatDate';
 
 interface JobDetailViewProps {
   job: CompanyPostDetailResponse | null;
   jobId: number;
-}
-
-function getDaysLeft(endDate: string): number | null {
-  if (!endDate) return null;
-  return Math.ceil((new Date(endDate).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
 }
 
 export default function JobDetailView({ job, jobId }: JobDetailViewProps) {
@@ -61,7 +57,8 @@ export default function JobDetailView({ job, jobId }: JobDetailViewProps) {
   const resumes = resumeData?.resume_list ?? [];
   const daysLeft = getDaysLeft(effectiveJob?.end_date ?? '');
   const isUrgent = daysLeft !== null && daysLeft >= 0 && daysLeft <= 3;
-  const isExpired = daysLeft !== null && daysLeft < 0;
+  // start_date == end_date 시드데이터는 마감으로 보지 않음 (ISSUE-114)
+  const isExpired = isPostExpired(effectiveJob?.start_date, effectiveJob?.end_date);
   const language = effectiveJob?.language ? effectiveJob.language.split(',').map(l => l.trim()) : [];
 
   const redirectToLogin = () => {
@@ -357,7 +354,7 @@ export default function JobDetailView({ job, jobId }: JobDetailViewProps) {
                   <div className="flex items-center gap-3 p-4 bg-amber-50 border border-amber-100 rounded-lg">
                     <Calendar className="text-amber-500 shrink-0" size={18} />
                     <p className="text-caption-1 text-slate-900">
-                      <span className="font-semibold">{t('recruitPeriod')}:</span> {effectiveJob.start_date} ~ {effectiveJob.end_date}
+                      <span className="font-semibold">{t('recruitPeriod')}:</span> {formatDateRange(effectiveJob.start_date, effectiveJob.end_date)}
                     </p>
                   </div>
                 </div>
@@ -484,8 +481,10 @@ export default function JobDetailView({ job, jobId }: JobDetailViewProps) {
                 {/* Recruitment Info */}
                 <div className="p-4 bg-slate-50 rounded-lg border border-slate-100 space-y-2 mt-6 pt-6 border-t">
                   <p className="text-caption-3 font-semibold text-slate-400">{tCommon('label.period')}</p>
-                  <p className="text-caption-1 font-semibold text-slate-900">{effectiveJob.start_date}</p>
-                  <p className="text-caption-1 text-slate-600">~ {effectiveJob.end_date}</p>
+                  <p className="text-caption-1 font-semibold text-slate-900">{formatDateShort(effectiveJob.start_date)}</p>
+                  {effectiveJob.end_date && effectiveJob.start_date !== effectiveJob.end_date && (
+                    <p className="text-caption-1 text-slate-600">~ {formatDateShort(effectiveJob.end_date)}</p>
+                  )}
                 </div>
               </motion.div>
             </div>

--- a/src/features/jobs/pages/JobsListView.tsx
+++ b/src/features/jobs/pages/JobsListView.tsx
@@ -131,8 +131,8 @@ export default function JobsListView({
       const q = searchQuery.toLowerCase();
       result = result.filter(
         p =>
-          p.title.toLowerCase().includes(q) ||
-          p.work_location?.toLowerCase().includes(q)
+          (p.title ?? '').toLowerCase().includes(q) ||
+          (p.work_location ?? '').toLowerCase().includes(q)
       );
     }
 

--- a/src/features/jobs/pages/UserApplicationsClient.tsx
+++ b/src/features/jobs/pages/UserApplicationsClient.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
+import { Briefcase, Clock } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import Layout from '@/shared/components/layout/Layout';
+import { Skeleton } from '@/shared/ui/Skeleton';
+import { postsApi } from '@/features/jobs/api/postsApi';
+import { FetchError } from '@/shared/api/fetchClient';
+
+/**
+ * ISSUE-110 + ISSUE-121: /user/applications 지원 내역 페이지.
+ * 서버 GET /api/applications/me 가 아직 미구현(404)이어서 구현 전까지 준비 중 화면을 표시.
+ * 서버 구현 완료 시 applications 배열을 렌더링하도록 확장.
+ */
+function UserApplicationsClient() {
+  const t = useTranslations('user.applications');
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['applications', 'me'],
+    queryFn: () => postsApi.getMyApplications(),
+    retry: false,
+  });
+
+  const applications = data?.applications ?? [];
+  const isNotImplemented = error instanceof FetchError && error.status === 404;
+
+  return (
+    <Layout>
+      <div className="min-h-screen bg-white py-8 sm:py-12">
+        <div className="page-container space-y-6">
+          <div>
+            <h1 className="text-title-3 sm:text-title-2 font-extrabold text-slate-900">
+              {t('title')}
+            </h1>
+            <p className="text-caption-1 sm:text-body-3 text-slate-500 mt-1">
+              {t('subtitle')}
+            </p>
+          </div>
+
+          {isLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-20 w-full rounded-xl" />
+              ))}
+            </div>
+          ) : isNotImplemented ? (
+            <div className="bg-slate-50 rounded-xl p-12 text-center">
+              <Clock className="mx-auto mb-3 text-slate-300" size={40} />
+              <p className="text-body-3 font-semibold text-slate-700 mb-1">
+                {t('notImplementedTitle')}
+              </p>
+              <p className="text-caption-1 text-slate-500 mb-6">
+                {t('notImplementedSubtitle')}
+              </p>
+              <Link
+                href="/jobs"
+                className="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg text-body-3 font-semibold hover:bg-blue-700 transition-colors"
+              >
+                {t('browseJobs')}
+              </Link>
+            </div>
+          ) : applications.length === 0 ? (
+            <div className="bg-slate-50 rounded-xl p-12 text-center">
+              <Briefcase className="mx-auto mb-3 text-slate-300" size={40} />
+              <p className="text-body-3 font-semibold text-slate-700 mb-1">
+                {t('emptyTitle')}
+              </p>
+              <p className="text-caption-1 text-slate-500 mb-6">
+                {t('emptySubtitle')}
+              </p>
+              <Link
+                href="/jobs"
+                className="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg text-body-3 font-semibold hover:bg-blue-700 transition-colors"
+              >
+                {t('browseJobs')}
+              </Link>
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {applications.map((app) => (
+                <li
+                  key={app.id}
+                  className="flex items-center justify-between bg-white border border-slate-200 rounded-xl p-4"
+                >
+                  <div className="min-w-0">
+                    <p className="text-body-3 font-semibold text-slate-900 truncate">
+                      공고 #{app.post_id}
+                    </p>
+                    <p className="text-caption-2 text-slate-500 mt-1">
+                      {t('appliedOn', { date: new Date(app.applied_at).toLocaleDateString() })}
+                    </p>
+                  </div>
+                  <span className="inline-flex items-center px-2.5 py-1 rounded-full text-caption-3 font-semibold bg-blue-50 text-blue-700 border border-blue-100">
+                    {app.status}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+export default UserApplicationsClient;

--- a/src/features/jobs/pages/UserBookmarksClient.tsx
+++ b/src/features/jobs/pages/UserBookmarksClient.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
+import { Bookmark } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import Layout from '@/shared/components/layout/Layout';
+import JobCard from '@/features/jobs/components/JobCard';
+import { Skeleton } from '@/shared/ui/Skeleton';
+import { postsApi } from '@/features/jobs/api/postsApi';
+import { useBookmarks } from '@/features/jobs/hooks/useBookmarks';
+import type { CompanyPost } from '@/shared/types/api';
+
+/**
+ * ISSUE-110: /user/bookmarks — 클라이언트 localStorage 북마크 목록.
+ * 서버 북마크 엔드포인트 구현(ISSUE-109) 전까지는 localStorage 기준으로 표시.
+ */
+function UserBookmarksClient() {
+  const t = useTranslations('user.bookmarks');
+  const { bookmarks } = useBookmarks();
+
+  // 전체 공고에서 북마크된 id 만 필터. 서버 쪽 GET /api/posts/company/bookmarks 미구현.
+  const { data, isLoading } = useQuery({
+    queryKey: ['public-jobs', 'all', 1],
+    queryFn: () => postsApi.getPublicCompanyPosts({ page: 1, limit: 100 }),
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+
+  const allPosts = data?.company_posts ?? [];
+  const bookmarkedPosts = allPosts.filter((p: CompanyPost) => bookmarks.includes(p.id));
+
+  return (
+    <Layout>
+      <div className="min-h-screen bg-white py-8 sm:py-12">
+        <div className="page-container space-y-6">
+          <div>
+            <h1 className="text-title-3 sm:text-title-2 font-extrabold text-slate-900">
+              {t('title')}
+            </h1>
+            <p className="text-caption-1 sm:text-body-3 text-slate-500 mt-1">
+              {t('subtitle', { count: bookmarks.length })}
+            </p>
+          </div>
+
+          {isLoading ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-64 w-full rounded-xl" />
+              ))}
+            </div>
+          ) : bookmarkedPosts.length === 0 ? (
+            <div className="bg-slate-50 rounded-xl p-12 text-center">
+              <Bookmark className="mx-auto mb-3 text-slate-300" size={40} />
+              <p className="text-body-3 font-semibold text-slate-700 mb-1">{t('emptyTitle')}</p>
+              <p className="text-caption-1 text-slate-500 mb-6">{t('emptySubtitle')}</p>
+              <Link
+                href="/jobs"
+                className="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg text-body-3 font-semibold hover:bg-blue-700 transition-colors"
+              >
+                {t('browseJobs')}
+              </Link>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+              {bookmarkedPosts.map((post: CompanyPost) => (
+                <JobCard key={post.id} post={post} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+export default UserBookmarksClient;

--- a/src/features/landing/components/sections/CTASection.tsx
+++ b/src/features/landing/components/sections/CTASection.tsx
@@ -32,7 +32,7 @@ export default function CTASection() {
       className="relative py-16 sm:py-20 lg:py-28 overflow-hidden"
     >
       {/* 배경 그래디언트 */}
-      <div className="absolute inset-0 bg-linear-to-br from-primary-600 via-primary-700 to-primary-900" />
+      <div className="absolute inset-0 bg-linear-to-br from-blue-600 via-blue-700 to-blue-900" />
 
       {/* 장식 원 1 */}
       <div className="absolute top-0 right-0 w-72 sm:w-96 h-72 sm:h-96 bg-blue-400/20 rounded-full -mr-36 sm:-mr-48 -mt-36 sm:-mt-48 blur-3xl" />

--- a/src/features/landing/components/sections/EventBannerSection.tsx
+++ b/src/features/landing/components/sections/EventBannerSection.tsx
@@ -8,8 +8,8 @@ import { getTranslations } from 'next-intl/server';
 function EventTypeBadge({ type, labels }: { type: EventType; labels: Record<EventType, string> }) {
   const styles: Record<EventType, string> = {
     notice: 'bg-blue-100 text-blue-700',
-    event: 'bg-amber-500-bg text-amber-500',
-    promotion: 'bg-emerald-500-bg text-emerald-500',
+    event: 'bg-amber-50 text-amber-500',
+    promotion: 'bg-emerald-50 text-emerald-500',
   };
   return (
     <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-caption-3 font-semibold ${styles[type]}`}>
@@ -34,7 +34,7 @@ function EventCard({ event, labels }: { event: Event; labels: Record<EventType, 
           />
         </div>
       ) : (
-        <div className="h-40 bg-linear-to-br from-primary-50 to-primary-100 flex items-center justify-center">
+        <div className="h-40 bg-linear-to-br from-blue-50 to-blue-100 flex items-center justify-center">
           <span className="text-title-1 select-none">
             {event.type === 'notice' ? '📢' : event.type === 'event' ? '🎉' : '🎁'}
           </span>

--- a/src/features/landing/components/sections/Footer.tsx
+++ b/src/features/landing/components/sections/Footer.tsx
@@ -1,18 +1,22 @@
-import Link from 'next/link';
+'use client';
 
-const links = [
-  { name: '채용 공고 찾아보기', href: '/jobs' },
-  { name: '이용약관', href: '/terms' },
-  { name: '개인정보처리방침', href: '/privacy' },
-  { name: '고객센터', href: '/support' },
-  { name: '자주 묻는 질문', href: '/faq' },
-];
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 
 export default function Footer() {
+  const t = useTranslations('common.footer');
+
+  const links = [
+    { name: t('jobsLink'), href: '/jobs' },
+    { name: t('terms'), href: '/terms' },
+    { name: t('privacy'), href: '/privacy' },
+    { name: t('supportLink'), href: '/support' },
+    { name: t('faq'), href: '/faq' },
+  ];
+
   return (
     <footer className="bg-white border-t border-slate-100 py-6">
       <div className="page-container flex flex-col items-center gap-3">
-        {/* 링크 */}
         <nav className="flex flex-wrap justify-center gap-x-6 gap-y-2">
           {links.map((link) => (
             <Link
@@ -25,9 +29,8 @@ export default function Footer() {
           ))}
         </nav>
 
-        {/* 저작권 */}
         <p className="text-caption-2 text-slate-400">
-          © 2026 Work In Korea. All rights reserved.
+          {t('allRights', { year: new Date().getFullYear() })}
         </p>
       </div>
     </footer>

--- a/src/features/landing/components/sections/HeroSection.tsx
+++ b/src/features/landing/components/sections/HeroSection.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { ArrowRight } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
+import { useAuth } from '@/features/auth/hooks/useAuth';
 import HeroSearchClient from './HeroSearchClient';
 
 const container = {
@@ -22,6 +23,9 @@ const item = {
 
 export default function HeroSection() {
   const t = useTranslations('landing.hero');
+  const { isAuthenticated, userType, isLoading: authLoading } = useAuth();
+  const loggedIn = !authLoading && isAuthenticated;
+  const dashboardHref = userType === 'company' ? '/company' : userType === 'admin' ? '/admin' : '/user/profile';
 
   return (
     <section className="bg-white min-h-[calc(100vh-65px)] sm:min-h-screen flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
@@ -59,22 +63,22 @@ export default function HeroSection() {
           {t('tagline')}
         </motion.p>
 
-        {/* 설명 */}
+        {/* 설명 — 로그인 상태에 따라 CTA 문구 변경 (ISSUE-127) */}
         <motion.p
           variants={item}
           className="text-caption-1 sm:text-body-3 text-slate-500 mb-8"
         >
-          {t('loginPrompt')}
+          {loggedIn ? t('welcomeBack') : t('loginPrompt')}
         </motion.p>
 
-        {/* CTA 버튼 */}
+        {/* CTA 버튼 — 로그인 여부에 따라 분기 */}
         <motion.div variants={item} whileHover={{ scale: 1.04 }} whileTap={{ scale: 0.97 }}>
           <Link
-            href="/login-select"
+            href={loggedIn ? dashboardHref : '/login-select'}
             className="inline-flex items-center gap-2 bg-blue-600 text-white hover:bg-blue-700 px-8 py-3.5 rounded-lg font-semibold text-body-2 transition-all shadow-md hover:shadow-lg"
             style={{ color: '#ffffff' }}
           >
-            {t('getStarted')}
+            {loggedIn ? t('goToDashboard') : t('getStarted')}
             <ArrowRight className="w-4 h-4" />
           </Link>
         </motion.div>

--- a/src/features/landing/components/sections/JobCategoriesSection.tsx
+++ b/src/features/landing/components/sections/JobCategoriesSection.tsx
@@ -14,7 +14,7 @@ export default function JobCategoriesSection() {
     { id: 'sales',     title: t('sales'),     icon: TrendingUp,    bgColor: 'bg-orange-50', iconColor: 'text-orange-600' },
     { id: 'finance',   title: t('finance'),   icon: Building,      bgColor: 'bg-yellow-50', iconColor: 'text-yellow-600' },
     { id: 'education', title: t('education'), icon: GraduationCap, bgColor: 'bg-indigo-50', iconColor: 'text-indigo-600' },
-    { id: 'food',      title: t('food'),      icon: ChefHat,       bgColor: 'bg-red-500-bg',    iconColor: 'text-red-500' },
+    { id: 'food',      title: t('food'),      icon: ChefHat,       bgColor: 'bg-red-50',    iconColor: 'text-red-500' },
     { id: 'startup',   title: t('startup'),   icon: Rocket,        bgColor: 'bg-teal-50',   iconColor: 'text-teal-600' },
   ];
 

--- a/src/features/landing/components/sections/PopularJobsSection.tsx
+++ b/src/features/landing/components/sections/PopularJobsSection.tsx
@@ -174,7 +174,7 @@ export default function PopularJobsSection() {
                       {/* 회사명과 시간 */}
                       <div className="flex items-start justify-between mb-3 md:mb-4">
                         <div className="flex items-center gap-2 md:gap-3">
-                          <div className="w-10 h-10 md:w-12 md:h-12 bg-linear-to-br from-primary-500 to-primary-700 rounded-lg flex items-center justify-center text-white font-bold text-body-3 md:text-body-1 shrink-0">
+                          <div className="w-10 h-10 md:w-12 md:h-12 bg-linear-to-br from-blue-500 to-blue-700 rounded-lg flex items-center justify-center text-white font-bold text-body-3 md:text-body-1 shrink-0">
                             {post.company_id}
                           </div>
                           <div>

--- a/src/features/landing/components/sections/ServicesSection.tsx
+++ b/src/features/landing/components/sections/ServicesSection.tsx
@@ -139,7 +139,7 @@ export default function ServicesSection() {
                   'absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300',
                   service.id === 'jobs'
                     ? 'bg-linear-to-br from-label-50 to-label-100/50'
-                    : 'bg-linear-to-br from-primary-50/50 to-primary-100/30'
+                    : 'bg-linear-to-br from-blue-50/50 to-blue-100/30'
                 )} />
 
                 {/* Content */}

--- a/src/features/profile/components/sections/AccountSettingsSection.tsx
+++ b/src/features/profile/components/sections/AccountSettingsSection.tsx
@@ -137,8 +137,8 @@ function AccountSettingsSection({ form }: AccountSettingsSectionProps) {
       </div>
 
       {/* Card: Account Management (Danger Zone) */}
-      <div className="bg-red-500-bg border border-red-500-bg rounded-xl overflow-hidden">
-        <div className="flex items-center gap-2.5 px-5 sm:px-7 py-5 border-b border-red-500-bg">
+      <div className="bg-red-50 border border-red-200 rounded-xl overflow-hidden">
+        <div className="flex items-center gap-2.5 px-5 sm:px-7 py-5 border-b border-red-200">
           <span className="w-8 h-8 rounded-lg bg-red-100 flex items-center justify-center shrink-0">
             <AlertTriangle size={16} className="text-red-500" />
           </span>

--- a/src/features/profile/components/shared/ProfileImageUpload.tsx
+++ b/src/features/profile/components/shared/ProfileImageUpload.tsx
@@ -151,7 +151,7 @@ function ProfileImageUpload({
           ) : (
             // Fallback: Initials avatar
             <div
-              className="rounded-full bg-linear-to-br from-primary-100 to-primary-50 border-4 border-blue-100 flex items-center justify-center"
+              className="rounded-full bg-linear-to-br from-blue-100 to-blue-50 border-4 border-blue-100 flex items-center justify-center"
               style={{
                 width: `${size}px`,
                 height: `${size}px`,

--- a/src/features/profile/pages/MyProfileClient.tsx
+++ b/src/features/profile/pages/MyProfileClient.tsx
@@ -4,9 +4,10 @@ import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Edit3 } from 'lucide-react';
+import { Edit3, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
+import { useAuthStore } from '@/shared/stores/authStore';
 import Layout from '@/shared/components/layout/Layout';
 import UserProfileHeader from '@/features/user/components/UserProfileHeader';
 import dynamic from 'next/dynamic';
@@ -90,6 +91,18 @@ const mockMySkillStats = {
   industryRanking: 88
 };
 
+/**
+ * 지정 시간(8s) 이후에도 loading 상태가 지속되면 onTimeout 트리거.
+ * skeleton 을 그대로 두지 않고 재시도 UI 로 전환해 무한 skeleton 을 방지한다.
+ */
+function LoadingTimeoutTrigger({ onTimeout }: { onTimeout: () => void }) {
+  useEffect(() => {
+    const id = setTimeout(onTimeout, 8000);
+    return () => clearTimeout(id);
+  }, [onTimeout]);
+  return null;
+}
+
 function MyProfileClient() {
   const t = useTranslations('user.profile');
   const [activeTab, setActiveTab] = useState<'overview' | 'skills' | 'experience' | 'resume'>('overview');
@@ -97,6 +110,20 @@ function MyProfileClient() {
   const queryClient = useQueryClient();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [loadingTimedOut, setLoadingTimedOut] = useState(false);
+
+  // 모듈 로드 시점의 initialize() 가 백그라운드 탭에서 보류될 수 있어
+  // mount 시점에 한번 더 킥 (idempotent — 이미 초기화된 경우 no-op)
+  useEffect(() => {
+    useAuthStore.getState().initialize();
+    const onVisible = () => {
+      if (document.visibilityState === 'visible' && !useAuthStore.getState().isInitialized) {
+        useAuthStore.getState().initialize();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, []);
 
   useEffect(() => {
     if (searchParams.get('redirected') === '1') {
@@ -106,21 +133,22 @@ function MyProfileClient() {
   }, [searchParams, router]);
 
   // 프로필 데이터 조회
+  // refetchOnWindowFocus 를 true 로 두면 백그라운드 탭에서 초기 fetch가 포커스 전까지 보류되어
+  // skeleton 이 계속 표시되는 이슈가 있어 false 로 고정. 초기 fetch 는 mount 시 항상 실행.
   const { data: profileData, isLoading: profileLoading, error: profileError } = useQuery({
     queryKey: ['profile'],
     queryFn: () => profileApi.getProfile(),
     enabled: isAuthenticated,
     refetchOnMount: 'always',
-    refetchOnWindowFocus: true,
+    refetchOnWindowFocus: false,
   });
 
-  // 연락처 데이터 조회
   const { data: contactData, isLoading: contactLoading } = useQuery({
     queryKey: ['contact'],
     queryFn: () => profileApi.getContact(),
     enabled: isAuthenticated,
     refetchOnMount: 'always',
-    refetchOnWindowFocus: true,
+    refetchOnWindowFocus: false,
   });
 
   // 프로필과 연락처 데이터 병합 (API 데이터가 없으면 mock 데이터 사용)
@@ -233,6 +261,37 @@ function MyProfileClient() {
   };
 
   if (authLoading || isLoading) {
+    if (loadingTimedOut) {
+      return (
+        <Layout>
+          <div className="min-h-screen bg-white py-16 flex items-center justify-center px-4">
+            <div className="text-center max-w-md mx-auto">
+              <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-slate-100 flex items-center justify-center">
+                <RefreshCw className="w-8 h-8 text-slate-500" />
+              </div>
+              <h2 className="text-title-4 font-bold text-slate-900 mb-2">
+                {t('loadingTimeout.title')}
+              </h2>
+              <p className="text-caption-1 text-slate-500 mb-6">
+                {t('loadingTimeout.subtitle')}
+              </p>
+              <button
+                onClick={() => {
+                  setLoadingTimedOut(false);
+                  queryClient.invalidateQueries({ queryKey: ['profile'] });
+                  queryClient.invalidateQueries({ queryKey: ['contact'] });
+                  useAuthStore.getState().initialize();
+                }}
+                className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white text-caption-1 font-semibold rounded-lg hover:bg-blue-700 transition-colors cursor-pointer"
+              >
+                {t('loadingTimeout.retry')}
+              </button>
+            </div>
+          </div>
+        </Layout>
+      );
+    }
+
     return (
       <Layout>
         <div className="min-h-screen bg-slate-100 py-8">
@@ -244,6 +303,7 @@ function MyProfileClient() {
                 <div className="bg-slate-100 rounded-xl h-96"></div>
               </div>
             </div>
+            <LoadingTimeoutTrigger onTimeout={() => setLoadingTimedOut(true)} />
           </div>
         </div>
       </Layout>

--- a/src/features/profile/pages/MyProfileClient.tsx
+++ b/src/features/profile/pages/MyProfileClient.tsx
@@ -32,63 +32,30 @@ import { useAuth } from '@/features/auth/hooks/useAuth';
 import { ResumeListItem } from '@/shared/types/api';
 import { FetchError } from '@/shared/api/fetchClient';
 
-// Mock data for dashboard, skill management, and career management
-const mockMyProfile: UserProfile = {
+/**
+ * 비어있는 UserProfile 베이스.
+ * API 응답에 없는 필드(스킬/경력/자격증 등)는 빈 배열/0으로 두어
+ * 사용자가 하드코딩된 더미 데이터를 자신의 정보로 오인하지 않도록 한다. (ISSUE-111)
+ */
+const EMPTY_USER_PROFILE: Omit<UserProfile, 'createdAt' | 'updatedAt'> = {
   id: 'me',
-  name: '이지은',
-  email: 'jieun.lee@example.com',
+  name: '',
+  email: '',
   profileImage: undefined,
-  position: 'UX/UI 디자이너 & 프론트엔드 개발자',
-  location: '서울, 한국',
-  introduction: '사용자 경험에 중점을 둔 디자인과 개발을 동시에 하는 3년차 전문가입니다. 디자인과 코드 사이의 간극을 줄이는 것이 저의 목표입니다.',
-  experience: 3,
-  completedProjects: 8,
-  certifications: ['Adobe Certified Expert', 'Google UX Design'],
+  position: undefined,
+  location: undefined,
+  introduction: undefined,
+  experience: 0,
+  completedProjects: 0,
+  certifications: [],
   job_status: 'available',
-  skills: [
-    { id: '1', name: 'Figma', level: 95, average: 75, category: 'technical', description: 'UI/UX 디자인 툴의 고급 기능 활용' },
-    { id: '2', name: 'React', level: 75, average: 70, category: 'technical' },
-    { id: '3', name: 'CSS/SCSS', level: 90, average: 65, category: 'technical' },
-    { id: '4', name: 'JavaScript', level: 80, average: 70, category: 'technical' },
-    { id: '5', name: '사용자 연구', level: 85, average: 60, category: 'soft' },
-    { id: '6', name: '프로토타이핑', level: 90, average: 55, category: 'soft' },
-    { id: '7', name: '영어', level: 70, average: 55, category: 'language' },
-    { id: '8', name: '중국어', level: 50, average: 30, category: 'language' }
-  ],
-  education: [
-    {
-      id: '1',
-      institution: '홍익대학교',
-      degree: '학사',
-      field: '시각디자인학',
-      startDate: '2017-03',
-      endDate: '2021-02'
-    }
-  ],
-  languages: [
-    { name: '한국어', proficiency: 'native' },
-    { name: '영어', proficiency: 'intermediate' },
-    { name: '중국어', proficiency: 'beginner' }
-  ],
-  githubUrl: 'https://github.com/leejieun',
-  linkedinUrl: 'https://linkedin.com/in/leejieun',
-  portfolioUrl: 'https://leejieun.design',
-  preferredSalary: {
-    min: 4500,
-    max: 6000,
-    currency: '만원'
-  },
-  createdAt: '2023-06-15T00:00:00Z',
-  updatedAt: '2024-01-20T00:00:00Z'
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mockMySkillStats = {
-  totalSkills: 8,
-  aboveAverageSkills: 7,
-  topSkillCategory: 'technical',
-  overallScore: 78,
-  industryRanking: 88
+  skills: [],
+  education: [],
+  languages: [],
+  githubUrl: undefined,
+  linkedinUrl: undefined,
+  portfolioUrl: undefined,
+  preferredSalary: undefined,
 };
 
 /**
@@ -151,28 +118,29 @@ function MyProfileClient() {
     refetchOnWindowFocus: false,
   });
 
-  // 프로필과 연락처 데이터 병합 (API 데이터가 없으면 mock 데이터 사용)
+  // 프로필과 연락처 데이터 병합 — mock 데이터 미사용 (ISSUE-111).
+  // API에 없는 필드는 EMPTY_USER_PROFILE 의 빈 값을 유지.
   const profile: UserProfile | undefined = profileData ? {
-    ...mockMyProfile, // 기본값으로 mock 데이터 사용
+    ...EMPTY_USER_PROFILE,
     id: 'me',
-    name: profileData.name || mockMyProfile.name,
-    email: mockMyProfile.email, // 이메일은 별도 API나 auth에서 가져와야 함
+    name: profileData.name || '',
+    email: '', // ProfileResponse 에 email 이 없음 — 서버 측 필드 추가 필요
     profileImage: profileData.profile_image_url || undefined,
-    position: mockMyProfile.position, // position은 position_id를 매핑해야 함
-    location: profileData.location || mockMyProfile.location,
-    introduction: profileData.introduction || mockMyProfile.introduction,
+    position: undefined,
+    location: profileData.location || undefined,
+    introduction: profileData.introduction || undefined,
     job_status: (profileData.job_status as 'available' | 'busy' | 'not-looking') || 'available',
     languages: profileData.language_skills
       ?.filter(skill => skill.language_type && skill.level)
       .map(skill => ({
         name: skill.language_type || '',
         proficiency: (skill.level as 'native' | 'advanced' | 'intermediate' | 'beginner') || 'beginner'
-      })) || mockMyProfile.languages,
-    githubUrl: contactData?.github_url || mockMyProfile.githubUrl,
-    linkedinUrl: contactData?.linkedin_url || mockMyProfile.linkedinUrl,
-    portfolioUrl: contactData?.website_url || profileData.portfolio_url || mockMyProfile.portfolioUrl,
+      })) || [],
+    githubUrl: contactData?.github_url || undefined,
+    linkedinUrl: contactData?.linkedin_url || undefined,
+    portfolioUrl: contactData?.website_url || profileData.portfolio_url || undefined,
     createdAt: profileData.created_at || new Date().toISOString(),
-    updatedAt: profileData.created_at || new Date().toISOString()
+    updatedAt: profileData.created_at || new Date().toISOString(), // 서버에 updated_at 필드 추가 필요
   } : undefined;
 
   const isLoading = profileLoading || contactLoading;

--- a/src/features/resume/components/ResumeEditor.tsx
+++ b/src/features/resume/components/ResumeEditor.tsx
@@ -40,6 +40,66 @@ interface ResumeEditorProps {
   resumeId?: number | null;
 }
 
+/**
+ * initialData 로부터 폼 기본값을 계산.
+ * useForm 초기값과 async prefill 용 reset() 호출 양쪽에서 재사용한다.
+ */
+function buildFormDefaults(initialData?: Resume): ResumeFormData {
+  return {
+    title: initialData?.title || '',
+    profile_url: initialData?.content?.personalInfo?.profileImage || '',
+    language_skills: initialData?.content?.languages?.map(lang => ({
+      language_type: lang.name,
+      level: lang.proficiency,
+    })) || [{ language_type: '', level: '' }],
+    schools: initialData?.content?.education?.map(edu => ({
+      school_name: edu.institution,
+      major_name: edu.field,
+      start_date: edu.startDate,
+      end_date: edu.endDate,
+      is_graduated: edu.degree === '졸업',
+    })) || [{
+      school_name: '',
+      major_name: '',
+      start_date: '',
+      end_date: undefined,
+      is_graduated: false,
+    }],
+    career_history: initialData?.content?.workExperience?.map(work => ({
+      company_name: work.company,
+      start_date: work.startDate,
+      end_date: work.endDate,
+      is_working: work.current || false,
+      department: '',
+      position_title: work.position,
+      main_role: work.description || '',
+    })) || [{
+      company_name: '',
+      start_date: '',
+      end_date: undefined,
+      is_working: false,
+      department: '',
+      position_title: '',
+      main_role: '',
+    }],
+    introduction: initialData?.content?.objective ? [{
+      title: '',
+      content: initialData.content.objective,
+    }] : [{ title: '', content: '' }],
+    licenses: initialData?.licenses && initialData.licenses.length > 0
+      ? initialData.licenses.map(license => ({
+          license_name: license.license_name,
+          license_agency: license.license_agency,
+          license_date: license.license_date,
+        }))
+      : initialData?.content?.certifications?.map(cert => ({
+          license_name: cert,
+          license_agency: '',
+          license_date: '',
+        })) || [{ license_name: '', license_agency: '', license_date: '' }],
+  };
+}
+
 type ResumeFormData = {
   title: string;
   profile_url?: string;
@@ -109,61 +169,17 @@ function ResumeEditor({
     initialData?.content?.personalInfo?.profileImage || null
   );
 
-  const { control, handleSubmit, watch, setValue, formState: { isSubmitting } } = useForm<ResumeFormData>({
-    defaultValues: {
-      title: initialData?.title || '',
-      profile_url: initialData?.content?.personalInfo?.profileImage || '',
-      language_skills: initialData?.content?.languages?.map(lang => ({
-        language_type: lang.name,
-        level: lang.proficiency
-      })) || [{ language_type: '', level: '' }],
-      schools: initialData?.content?.education?.map(edu => ({
-        school_name: edu.institution,
-        major_name: edu.field,
-        start_date: edu.startDate,
-        end_date: edu.endDate,
-        is_graduated: edu.degree === '졸업'
-      })) || [{
-        school_name: '',
-        major_name: '',
-        start_date: '',
-        end_date: undefined,
-        is_graduated: false
-      }],
-      career_history: initialData?.content?.workExperience?.map(work => ({
-        company_name: work.company,
-        start_date: work.startDate,
-        end_date: work.endDate,
-        is_working: work.current || false,
-        department: '',
-        position_title: work.position,
-        main_role: work.description || ''
-      })) || [{
-        company_name: '',
-        start_date: '',
-        end_date: undefined,
-        is_working: false,
-        department: '',
-        position_title: '',
-        main_role: ''
-      }],
-      introduction: initialData?.content?.objective ? [{
-        title: '',
-        content: initialData.content.objective
-      }] : [{ title: '', content: '' }],
-      licenses: initialData?.licenses && initialData.licenses.length > 0
-        ? initialData.licenses.map(license => ({
-            license_name: license.license_name,
-            license_agency: license.license_agency,
-            license_date: license.license_date
-          }))
-        : initialData?.content?.certifications?.map(cert => ({
-            license_name: cert,
-            license_agency: '',
-            license_date: ''
-          })) || [{ license_name: '', license_agency: '', license_date: '' }]
-    }
+  const { control, handleSubmit, watch, setValue, reset, formState: { isSubmitting } } = useForm<ResumeFormData>({
+    defaultValues: buildFormDefaults(initialData),
   });
+
+  // ISSUE-105: initialData 가 비동기로 도착/변경되는 경우 reset 으로 폼을 재초기화.
+  // useForm defaultValues 는 첫 렌더에만 반영되므로 async fetch 후에는 reset 이 필요하다.
+  useEffect(() => {
+    if (isEditMode && initialData) {
+      reset(buildFormDefaults(initialData));
+    }
+  }, [isEditMode, initialData, reset]);
 
   // ISSUE-29: 프로필 데이터가 로드되면 이름으로 이력서 제목 프리필
   useEffect(() => {

--- a/src/features/resume/components/ResumeEditor.tsx
+++ b/src/features/resume/components/ResumeEditor.tsx
@@ -28,6 +28,7 @@ import { resumeApi } from '@/features/resume/api/resumeApi';
 import { profileApi } from '@/features/profile/api/profileApi';
 import { FormField } from '@/shared/ui/FormField';
 import DatePicker from '@/shared/ui/DatePicker';
+import { FetchError } from '@/shared/api/fetchClient';
 import type {
   CreateResumeRequest,
   UpdateResumeRequest
@@ -214,6 +215,7 @@ function ResumeEditor({
   });
 
   // 이력서 생성 뮤테이션
+  // 422 는 onSubmit catch 에서 필드별 메시지로 처리하므로 여기서는 토스트 중복 방지.
   const createResumeMutation = useMutation({
     mutationFn: async (data: CreateResumeRequest) => {
       return resumeApi.createResume(data);
@@ -223,7 +225,8 @@ function ResumeEditor({
       toast.success(t('createSuccess'));
       router.push('/user');
     },
-    onError: () => {
+    onError: (error: Error) => {
+      if (error instanceof FetchError && error.status === 422) return;
       toast.error(t('createError'));
     }
   });
@@ -240,54 +243,91 @@ function ResumeEditor({
       toast.success(t('updateSuccess'));
       router.push('/user');
     },
-    onError: () => {
+    onError: (error: Error) => {
+      if (error instanceof FetchError && error.status === 422) return;
       toast.error(t('updateError'));
     }
   });
 
   const onSubmit = async (data: ResumeFormData) => {
+    // 학력사항: 기본 필드가 모두 비어있는 row 는 제외.
+    // 남은 row 도 end_date 미지정 시 키 자체를 제거하여 Pydantic validation 통과.
+    const filteredSchools = data.schools.filter(
+      (s) => s.school_name?.trim() || s.major_name?.trim() || s.start_date
+    );
+    const processedSchools = filteredSchools.length > 0
+      ? filteredSchools.map((school) => {
+          const { end_date, ...rest } = school;
+          return end_date ? { ...rest, end_date } : rest;
+        })
+      : undefined;
+
+    // 경력사항: 회사명/시작일 중 하나도 없는 row 제외.
+    const filteredCareer = data.career_history.filter(
+      (c) => c.company_name?.trim() || c.start_date
+    );
+    const processedCareerHistory = filteredCareer.length > 0
+      ? filteredCareer.map((career) => {
+          const { end_date, ...rest } = career;
+          // 재직중이면 end_date 제거, 종료일 미입력도 제거
+          if (end_date && !career.is_working) {
+            return { ...rest, end_date };
+          }
+          return rest;
+        })
+      : undefined;
+
+    // 언어: language_type + level 둘 다 있을 때만 포함
+    const filteredLanguages = data.language_skills.filter(
+      (l) => l.language_type?.trim() && l.level?.trim()
+    );
+
+    // 자기소개: title 또는 content 중 하나라도 있을 때만 포함
+    const filteredIntroduction = data.introduction.filter(
+      (i) => i.title?.trim() || i.content?.trim()
+    );
+
+    // 자격증: license_name 필수
+    const filteredLicenses = data.licenses.filter(
+      (l) => l.license_name?.trim()
+    );
+
+    const requestData: CreateResumeRequest | UpdateResumeRequest = {
+      title: data.title?.trim(),
+      profile_url: data.profile_url || undefined,
+      language_skills: filteredLanguages.length > 0 ? filteredLanguages : undefined,
+      schools: processedSchools,
+      career_history: processedCareerHistory,
+      introduction: filteredIntroduction.length > 0 ? filteredIntroduction : undefined,
+      licenses: filteredLicenses.length > 0 ? filteredLicenses : undefined,
+    };
+
     try {
-      // 재직중일 때 또는 선택 안 했을 때 end_date를 제거
-      const processedCareerHistory = data.career_history.length > 0
-        ? data.career_history.map(career => {
-            const { end_date, ...rest } = career;
-            // end_date가 있고 재직중이 아닐 때만 포함
-            if (end_date && !career.is_working) {
-              return { ...rest, end_date };
-            }
-            return rest;
-          })
-        : undefined;
-
-      // 학력사항의 end_date도 선택 안 했을 때 제거
-      const processedSchools = data.schools.length > 0
-        ? data.schools.map(school => {
-            const { end_date, ...rest } = school;
-            // end_date가 있을 때만 포함
-            if (end_date) {
-              return { ...rest, end_date };
-            }
-            return rest;
-          })
-        : undefined;
-
-      const requestData: CreateResumeRequest | UpdateResumeRequest = {
-        title: data.title,
-        profile_url: data.profile_url || undefined,
-        language_skills: data.language_skills.length > 0 ? data.language_skills : undefined,
-        schools: processedSchools,
-        career_history: processedCareerHistory,
-        introduction: data.introduction.length > 0 ? data.introduction : undefined,
-        licenses: data.licenses.length > 0 ? data.licenses : undefined,
-      };
-
       if (isEditMode && resumeId) {
         await updateResumeMutation.mutateAsync(requestData as UpdateResumeRequest);
       } else {
         await createResumeMutation.mutateAsync(requestData as CreateResumeRequest);
       }
     } catch (error) {
-      // mutation onError handles user-facing error
+      // 422: Pydantic validation 실패 → 필드별 에러 메시지 수집해 사용자에게 노출
+      if (error instanceof FetchError && error.status === 422) {
+        const detail = (error.data as { detail?: unknown })?.detail;
+        if (Array.isArray(detail)) {
+          const messages = detail
+            .slice(0, 3)
+            .map((d: { loc?: unknown[]; msg?: string }) => {
+              const field = Array.isArray(d.loc) ? d.loc.filter(x => x !== 'body').join('.') : '';
+              return field ? `${field}: ${d.msg ?? ''}` : d.msg ?? '';
+            })
+            .filter(Boolean);
+          if (messages.length > 0) {
+            toast.error(messages.join('\n'));
+            return;
+          }
+        }
+        toast.error(t('validationError'));
+      }
+      // 기타 에러는 mutation onError 에서 처리
     }
   };
 

--- a/src/features/resume/components/ResumeEditor.tsx
+++ b/src/features/resume/components/ResumeEditor.tsx
@@ -453,7 +453,7 @@ function ResumeEditor({
                     <button
                       type="button"
                       onClick={handleRemoveImage}
-                      className="absolute -top-2 -right-2 bg-red-500-bg0 text-white rounded-full p-1 hover:bg-red-600 transition-colors cursor-pointer"
+                      className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1 hover:bg-red-600 transition-colors cursor-pointer"
                     >
                       <X size={14} />
                     </button>
@@ -546,7 +546,7 @@ function ResumeEditor({
                   <button
                     type="button"
                     onClick={() => removeIntro(index)}
-                    className="text-red-500 hover:bg-red-600-bg p-1 rounded cursor-pointer"
+                    className="text-red-500 hover:bg-red-50 p-1 rounded cursor-pointer"
                   >
                     <Trash2 size={14} />
                   </button>
@@ -643,7 +643,7 @@ function ResumeEditor({
                   <button
                     type="button"
                     onClick={() => removeCareer(index)}
-                    className="text-red-500 hover:bg-red-600-bg p-1 rounded cursor-pointer"
+                    className="text-red-500 hover:bg-red-50 p-1 rounded cursor-pointer"
                   >
                     <Trash2 size={14} />
                   </button>
@@ -814,7 +814,7 @@ function ResumeEditor({
                   <button
                     type="button"
                     onClick={() => removeSchool(index)}
-                    className="text-red-500 hover:bg-red-600-bg p-1 rounded cursor-pointer"
+                    className="text-red-500 hover:bg-red-50 p-1 rounded cursor-pointer"
                   >
                     <Trash2 size={14} />
                   </button>
@@ -957,7 +957,7 @@ function ResumeEditor({
                   <button
                     type="button"
                     onClick={() => removeLanguage(index)}
-                    className="text-red-500 hover:bg-red-600-bg p-1 rounded cursor-pointer"
+                    className="text-red-500 hover:bg-red-50 p-1 rounded cursor-pointer"
                   >
                     <Trash2 size={14} />
                   </button>
@@ -1077,7 +1077,7 @@ function ResumeEditor({
                   <button
                     type="button"
                     onClick={() => removeLicense(index)}
-                    className="text-red-500 hover:bg-red-600-bg p-1 rounded cursor-pointer"
+                    className="text-red-500 hover:bg-red-50 p-1 rounded cursor-pointer"
                   >
                     <Trash2 size={14} />
                   </button>

--- a/src/features/user/components/SkillBarChart.tsx
+++ b/src/features/user/components/SkillBarChart.tsx
@@ -33,7 +33,7 @@ function SkillBarChart({
       case 'soft':
         return 'text-blue-600 bg-blue-50 border-blue-200';
       case 'language':
-        return 'text-amber-500 bg-amber-500-bg border-amber-200';
+        return 'text-amber-500 bg-amber-50 border-amber-200';
       default:
         return 'text-slate-600 bg-slate-100 border-slate-200';
     }
@@ -116,9 +116,9 @@ function SkillBarChart({
                 <div className={cn(
                   'text-caption-3 px-2 py-0.5 rounded font-medium',
                   skill.level > skill.average
-                    ? 'text-emerald-500 bg-emerald-500-bg'
+                    ? 'text-emerald-500 bg-emerald-50'
                     : skill.level < skill.average
-                    ? 'text-amber-500 bg-amber-500-bg'
+                    ? 'text-amber-500 bg-amber-50'
                     : 'text-slate-500 bg-slate-100'
                 )}>
                   {skill.level > skill.average ? '+' : ''}

--- a/src/features/user/components/UserProfileHeader.tsx
+++ b/src/features/user/components/UserProfileHeader.tsx
@@ -26,13 +26,13 @@ function UserProfileHeader({
       switch (jobStatus) {
         case 'available':
           return {
-            bg: 'bg-emerald-500-bg0',
+            bg: 'bg-emerald-500',
             text: 'text-white',
             label: t('statusAvailable')
           };
         case 'busy':
           return {
-            bg: 'bg-amber-500-bg0',
+            bg: 'bg-amber-500',
             text: 'text-white',
             label: t('statusBusy')
           };

--- a/src/features/user/pages/UserProfileClient.tsx
+++ b/src/features/user/pages/UserProfileClient.tsx
@@ -324,7 +324,7 @@ function UserProfileClient() {
           <button
             onClick={handleConfirmDelete}
             disabled={deleteResumeMutation.isPending}
-            className="px-4 py-2 bg-red-500-bg0 text-white rounded-lg text-body-3 font-medium hover:bg-red-600 transition-colors disabled:opacity-50 cursor-pointer"
+            className="px-4 py-2 bg-red-500 text-white rounded-lg text-body-3 font-medium hover:bg-red-600 transition-colors disabled:opacity-50 cursor-pointer"
           >
             {deleteResumeMutation.isPending ? t('deleting') : t('delete')}
           </button>
@@ -464,7 +464,7 @@ function UserProfileClient() {
                         <motion.div
                           className={cn(
                             'h-full rounded-full',
-                            pct >= 80 ? 'bg-blue-600' : pct >= 50 ? 'bg-amber-500-bg0' : 'bg-slate-300'
+                            pct >= 80 ? 'bg-blue-600' : pct >= 50 ? 'bg-amber-500' : 'bg-slate-300'
                           )}
                           initial={{ width: 0 }}
                           animate={{ width: `${pct}%` }}
@@ -537,7 +537,7 @@ function UserProfileClient() {
               <div className="space-y-5 sm:space-y-6">
                 {/* 파일 업로드 섹션 */}
                 <motion.div
-                  className="bg-linear-to-br from-primary-50 to-primary-100/50 rounded-xl p-4 sm:p-6 border border-blue-200 hover:border-blue-300 transition-colors"
+                  className="bg-linear-to-br from-blue-50 to-blue-100/50 rounded-xl p-4 sm:p-6 border border-blue-200 hover:border-blue-300 transition-colors"
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ duration: 0.4 }}
@@ -617,7 +617,7 @@ function UserProfileClient() {
                             handleDeleteResume(resume.id, resume.title || '이력서');
                           }}
                           disabled={deleteResumeMutation.isPending}
-                          className="px-3 sm:px-4 py-2 sm:py-2.5 text-caption-3 sm:text-caption-2 font-semibold text-red-500 border border-red-500-bg rounded-lg hover:bg-red-600-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer shrink-0"
+                          className="px-3 sm:px-4 py-2 sm:py-2.5 text-caption-3 sm:text-caption-2 font-semibold text-red-500 border border-red-200 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer shrink-0"
                           whileHover={{ scale: 1.05 }}
                           whileTap={{ scale: 0.95 }}
                         >
@@ -714,7 +714,7 @@ function UserProfileClient() {
                     transition={{ duration: 0.4, delay: 0.1 }}
                   >
                     <div className="flex items-center gap-3 mb-4 sm:mb-5">
-                      <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-lg bg-amber-500-bg flex items-center justify-center shrink-0">
+                      <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-lg bg-amber-50 flex items-center justify-center shrink-0">
                         <Award className="w-4 h-4 sm:w-5 sm:h-5 text-amber-500" />
                       </div>
                       <h3 className="text-body-3 sm:text-body-2 font-bold text-slate-900">{t('certTitle')}</h3>

--- a/src/shared/api/__tests__/fetchClient.test.ts
+++ b/src/shared/api/__tests__/fetchClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { fetchAPI, fetchClient, FetchError, API_BASE_URL, SERVER_API_URL } from '../fetchClient';
+import { fetchAPI, fetchClient, FetchError, API_BASE_URL, SERVER_API_URL, __resetRefreshState } from '../fetchClient';
 import { tokenStore } from '../tokenStore';
 
 /**
@@ -20,6 +20,7 @@ describe('fetchAPI', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     tokenStore.clear();
+    __resetRefreshState();
     global.fetch = vi.fn();
   });
 
@@ -199,6 +200,63 @@ describe('fetchAPI', () => {
       // Should only call fetch once (no recursive refresh)
       expect(global.fetch).toHaveBeenCalledOnce();
     });
+
+    it('should share a single refresh request across concurrent 401s (single-flight)', async () => {
+      const refreshResponse = { access_token: 'new-token' };
+      const retryData = { ok: true };
+
+      // Two concurrent requests both 401, then share one refresh, then each retries
+      vi.mocked(global.fetch).mockImplementation((input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : (input as Request).url ?? String(input);
+        if (url.includes('/auth/refresh')) {
+          return Promise.resolve(mockFetchResponse(200, refreshResponse) as unknown as Response);
+        }
+        // alternating 401 → then retry 200. Use call count to determine phase.
+        const callCount = vi.mocked(global.fetch).mock.calls.length;
+        // first two calls are the initial 401s
+        if (callCount <= 2) {
+          return Promise.resolve(mockFetchResponse(401, { detail: 'Unauthorized' }) as unknown as Response);
+        }
+        return Promise.resolve(mockFetchResponse(200, retryData) as unknown as Response);
+      });
+
+      const [a, b] = await Promise.all([
+        fetchAPI<typeof retryData>('/api/a'),
+        fetchAPI<typeof retryData>('/api/b'),
+      ]);
+
+      expect(a).toEqual(retryData);
+      expect(b).toEqual(retryData);
+
+      // refresh should be called exactly once, not twice
+      const refreshCalls = vi.mocked(global.fetch).mock.calls.filter(([input]) => {
+        const url = typeof input === 'string' ? input : (input as Request).url ?? String(input);
+        return url.includes('/auth/refresh');
+      });
+      expect(refreshCalls.length).toBe(1);
+    });
+
+    it('should stop refreshing after 3 consecutive failures', async () => {
+      // Every fetch returns 401, every refresh returns 400
+      vi.mocked(global.fetch).mockImplementation((input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : (input as Request).url ?? String(input);
+        if (url.includes('/auth/refresh')) {
+          return Promise.resolve(mockFetchResponse(400, { detail: 'Refresh failed' }) as unknown as Response);
+        }
+        return Promise.resolve(mockFetchResponse(401, { detail: 'Unauthorized' }) as unknown as Response);
+      });
+
+      // Make 5 sequential requests; each should fail without exceeding 3 refresh attempts total
+      for (let i = 0; i < 5; i++) {
+        await expect(fetchAPI('/api/test')).rejects.toThrow(FetchError);
+      }
+
+      const refreshCalls = vi.mocked(global.fetch).mock.calls.filter(([input]) => {
+        const url = typeof input === 'string' ? input : (input as Request).url ?? String(input);
+        return url.includes('/auth/refresh');
+      });
+      expect(refreshCalls.length).toBeLessThanOrEqual(3);
+    }, 10_000);
 
     it('should throw FetchError when retry fails after successful refresh', async () => {
       const refreshResponse = { access_token: 'new-token' };
@@ -474,6 +532,7 @@ describe('fetchClient methods', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     tokenStore.clear();
+    __resetRefreshState();
     global.fetch = vi.fn();
   });
 

--- a/src/shared/api/fetchClient.ts
+++ b/src/shared/api/fetchClient.ts
@@ -146,31 +146,71 @@ export async function fetchAPI<T>(
  * Token Refresh (HttpOnly Cookie 기반)
  * - 백엔드가 자동으로 새로운 Cookie를 Set-Cookie 헤더로 전송
  * - 브라우저가 자동으로 새 쿠키를 저장
+ *
+ * Single-flight: 동시에 여러 요청이 401을 받아도 refresh는 한 번만 실행됨
+ * Retry limit: 연속 3회 실패 시 더 이상 refresh 시도하지 않고 즉시 false 반환
  */
+const MAX_CONSECUTIVE_REFRESH_FAILURES = 3;
+const REFRESH_BACKOFF_MS = [0, 300, 900, 2700] as const;
+
+let refreshPromise: Promise<boolean> | null = null;
+let consecutiveRefreshFailures = 0;
+
 async function refreshToken(isServer: boolean): Promise<boolean> {
-  try {
-    const baseURL = isServer ? SERVER_API_URL : API_BASE_URL;
+  // 이미 진행 중인 refresh가 있으면 그 Promise를 공유 (single-flight)
+  if (refreshPromise) {
+    return refreshPromise;
+  }
 
-    const response = await fetch(`${baseURL}/api/auth/refresh`, {
-      method: 'POST',
-      credentials: 'include', // refreshToken 쿠키 자동 전송
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (response.ok) {
-      const data = await response.json();
-      if (!isServer && data.access_token) {
-        tokenStore.set(data.access_token);
-      }
-      return true;
-    }
-
-    return false;
-  } catch (error) {
+  // 연속 실패 한도 도달 → 즉시 실패 반환 (루프 차단)
+  if (consecutiveRefreshFailures >= MAX_CONSECUTIVE_REFRESH_FAILURES) {
     return false;
   }
+
+  refreshPromise = (async () => {
+    try {
+      const backoff = REFRESH_BACKOFF_MS[consecutiveRefreshFailures] ?? 2700;
+      if (backoff > 0) {
+        await new Promise((resolve) => setTimeout(resolve, backoff));
+      }
+
+      const baseURL = isServer ? SERVER_API_URL : API_BASE_URL;
+      const response = await fetch(`${baseURL}/api/auth/refresh`, {
+        method: 'POST',
+        credentials: 'include', // refreshToken 쿠키 자동 전송
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        if (!isServer && data.access_token) {
+          tokenStore.set(data.access_token);
+        }
+        consecutiveRefreshFailures = 0;
+        return true;
+      }
+
+      consecutiveRefreshFailures++;
+      return false;
+    } catch {
+      consecutiveRefreshFailures++;
+      return false;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  return refreshPromise;
+}
+
+/**
+ * refresh 상태 초기화 (테스트 전용)
+ */
+export function __resetRefreshState(): void {
+  refreshPromise = null;
+  consecutiveRefreshFailures = 0;
 }
 
 /**

--- a/src/shared/components/BetaPopup.tsx
+++ b/src/shared/components/BetaPopup.tsx
@@ -57,7 +57,7 @@ export function BetaPopup() {
           >
             <div className="pointer-events-auto bg-white rounded-2xl shadow-xl max-w-sm w-full overflow-hidden">
               {/* header gradient bar */}
-              <div className="bg-gradient-to-r from-primary-600 to-primary-500 px-6 py-5 flex items-start justify-between">
+              <div className="bg-gradient-to-r from-blue-600 to-blue-500 px-6 py-5 flex items-start justify-between">
                 <div className="flex items-center gap-3">
                   <div className="w-9 h-9 bg-white/20 rounded-xl flex items-center justify-center shrink-0">
                     <FlaskConical size={18} className="text-white" />

--- a/src/shared/lib/utils/formatDate.ts
+++ b/src/shared/lib/utils/formatDate.ts
@@ -1,0 +1,71 @@
+/**
+ * 서버가 내려주는 ISO 8601 문자열 또는 YYYY-MM-DD 를 사용자 친화적인 날짜로 포맷팅한다.
+ *
+ * 서버 응답이 `2025-12-06T01:26:26.719000Z` 처럼 raw ISO 문자열로 UI에 노출되는
+ * 이슈(ISSUE-118) 방지용.
+ */
+
+const DEFAULT_LOCALE = 'ko-KR';
+
+export function formatDate(value: string | null | undefined, locale: string = DEFAULT_LOCALE): string {
+  if (!value) return '';
+  const date = new Date(value);
+  if (isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(date);
+}
+
+export function formatDateShort(value: string | null | undefined, locale: string = DEFAULT_LOCALE): string {
+  if (!value) return '';
+  const date = new Date(value);
+  if (isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date).replace(/\s/g, '');
+}
+
+/**
+ * 공고 기간 표시용. start == end 인 시드 데이터는 "상시"로 표기 (ISSUE-114).
+ */
+export function formatDateRange(
+  start: string | null | undefined,
+  end: string | null | undefined,
+  locale: string = DEFAULT_LOCALE,
+  alwaysOpenLabel: string = '상시',
+): string {
+  const s = formatDateShort(start, locale);
+  const e = formatDateShort(end, locale);
+  if (!s && !e) return '';
+  if (s && e && s === e) return alwaysOpenLabel;
+  if (s && e) return `${s} ~ ${e}`;
+  return s || `~ ${e}`;
+}
+
+/**
+ * 공고가 실제 마감되었는지 판정.
+ * - end_date 가 없으면 활성으로 간주
+ * - start_date == end_date (시드 데이터) 는 마감으로 보지 않음 (ISSUE-114)
+ * - end_date 가 현재 시각 이전이면 마감
+ */
+export function isPostExpired(start: string | null | undefined, end: string | null | undefined): boolean {
+  if (!end) return false;
+  if (start && end && start === end) return false;
+  const endDate = new Date(end);
+  if (isNaN(endDate.getTime())) return false;
+  return endDate.getTime() < Date.now();
+}
+
+/**
+ * 남은 일수 계산. 음수면 마감, null 이면 end_date 가 없거나 유효하지 않음.
+ */
+export function getDaysLeft(end: string | null | undefined): number | null {
+  if (!end) return null;
+  const endDate = new Date(end);
+  if (isNaN(endDate.getTime())) return null;
+  return Math.ceil((endDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+}

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -151,6 +151,8 @@ export interface AccountConfigUpdateRequest {
 
 export interface CompanyProfileResponse {
   company_id: number;
+  /** 서버가 아직 반환하지 않을 수 있음 (ISSUE-112) */
+  company_name?: string;
   industry_type: string;
   employee_count: number;
   establishment_date: string;

--- a/src/shared/ui/Badge.tsx
+++ b/src/shared/ui/Badge.tsx
@@ -8,9 +8,9 @@ type BadgeColor = 'primary' | 'secondary' | 'success' | 'warning' | 'danger' | '
 const colorMap: Record<BadgeColor, string> = {
   primary:   'bg-blue-50 text-blue-700 border-blue-200',
   secondary: 'bg-slate-100 text-slate-600 border-slate-200',
-  success:   'bg-emerald-500-bg text-emerald-500 border-emerald-500-bg',
-  warning:   'bg-amber-500-bg text-amber-500 border-amber-500-bg',
-  danger:    'bg-red-500-bg text-red-500 border-red-500-bg',
+  success:   'bg-emerald-50 text-emerald-500 border-emerald-100',
+  warning:   'bg-amber-50 text-amber-500 border-amber-200',
+  danger:    'bg-red-50 text-red-500 border-red-200',
   neutral:   'bg-slate-100 text-slate-500 border-slate-200',
 };
 

--- a/src/shared/ui/Callout.tsx
+++ b/src/shared/ui/Callout.tsx
@@ -37,7 +37,7 @@ const variantConfig: Record<
     DefaultIcon:  Info,
   },
   warning: {
-    container:    'bg-amber-500-bg border border-amber-500-bg',
+    container:    'bg-amber-50 border border-amber-200',
     iconColor:    'text-amber-500',
     titleColor:   'text-slate-800',
     bodyColor:    'text-slate-700',
@@ -45,7 +45,7 @@ const variantConfig: Record<
     DefaultIcon:  AlertTriangle,
   },
   error: {
-    container:    'bg-red-500-bg border border-red-500-bg',
+    container:    'bg-red-50 border border-red-200',
     iconColor:    'text-red-500',
     titleColor:   'text-slate-800',
     bodyColor:    'text-slate-700',
@@ -53,7 +53,7 @@ const variantConfig: Record<
     DefaultIcon:  XCircle,
   },
   success: {
-    container:    'bg-emerald-500-bg border border-emerald-500-bg',
+    container:    'bg-emerald-50 border border-emerald-100',
     iconColor:    'text-emerald-500',
     titleColor:   'text-slate-800',
     bodyColor:    'text-slate-700',

--- a/src/shared/ui/IconButton.tsx
+++ b/src/shared/ui/IconButton.tsx
@@ -15,7 +15,7 @@ const variantStyles: Record<NonNullable<IconButtonProps['variant']>, string> = {
   ghost:       'text-slate-600 hover:bg-slate-100 hover:text-slate-800',
   outline:     'text-slate-600 border border-slate-200 hover:bg-slate-50 hover:border-slate-200',
   filled:      'bg-blue-600 text-white hover:bg-blue-700 active:bg-blue-800',
-  destructive: 'text-red-500 hover:bg-red-600-bg',
+  destructive: 'text-red-500 hover:bg-red-50',
 };
 
 const sizeStyles: Record<NonNullable<IconButtonProps['size']>, { btn: string; icon: number }> = {

--- a/src/shared/ui/LoadingSpinner.tsx
+++ b/src/shared/ui/LoadingSpinner.tsx
@@ -14,7 +14,7 @@ const sizeMap = {
 };
 
 const colorMap = {
-  blue:  'border-blue-200 border-t-primary-600',
+  blue:  'border-blue-200 border-t-blue-600',
   white: 'border-white/30 border-t-white',
   slate: 'border-slate-200 border-t-label-500',
 };

--- a/src/shared/ui/ResumeCard.tsx
+++ b/src/shared/ui/ResumeCard.tsx
@@ -34,9 +34,9 @@ export function ResumeCard({
   const getStatusColor = (status: Resume['status']) => {
     switch (status) {
       case 'draft':
-        return 'bg-amber-500-bg text-amber-500 border-amber-500-bg';
+        return 'bg-amber-50 text-amber-500 border-amber-200';
       case 'completed':
-        return 'bg-emerald-500-bg text-emerald-500 border-emerald-500-bg';
+        return 'bg-emerald-50 text-emerald-500 border-emerald-100';
       case 'published':
         return 'bg-blue-50 text-blue-700 border-blue-200';
       default:
@@ -168,7 +168,7 @@ export function ResumeCard({
           </button>
           <button
             onClick={onDelete}
-            className="p-1.5 text-slate-500 hover:text-red-600 hover:bg-red-600-bg rounded-lg transition-colors cursor-pointer"
+            className="p-1.5 text-slate-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors cursor-pointer"
             title="삭제"
           >
             <Trash2 size={14} />

--- a/src/shared/ui/ResumeUpload.tsx
+++ b/src/shared/ui/ResumeUpload.tsx
@@ -131,7 +131,7 @@ const ResumeUpload: React.FC<ResumeUploadProps> = ({
       {/* 에러 메시지 */}
       {error && (
         <motion.div
-          className="flex items-center gap-2 p-3 bg-red-500-bg border border-red-500-bg rounded-lg"
+          className="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-lg"
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3 }}

--- a/src/shared/ui/StatCard.tsx
+++ b/src/shared/ui/StatCard.tsx
@@ -44,22 +44,22 @@ export function StatCard({
       border: 'border-slate-200'
     },
     success: {
-      bg: 'bg-emerald-500-bg',
+      bg: 'bg-emerald-50',
       icon: 'text-emerald-500',
       value: 'text-emerald-500',
-      border: 'border-emerald-500-bg'
+      border: 'border-emerald-100'
     },
     warning: {
-      bg: 'bg-amber-500-bg',
+      bg: 'bg-amber-50',
       icon: 'text-amber-500',
       value: 'text-amber-500',
-      border: 'border-amber-500-bg'
+      border: 'border-amber-200'
     },
     danger: {
-      bg: 'bg-red-500-bg',
+      bg: 'bg-red-50',
       icon: 'text-red-500',
       value: 'text-red-500',
-      border: 'border-red-500-bg'
+      border: 'border-red-200'
     },
     neutral: {
       bg: 'bg-slate-100',

--- a/src/shared/ui/__tests__/Badge.test.tsx
+++ b/src/shared/ui/__tests__/Badge.test.tsx
@@ -25,21 +25,21 @@ describe('Badge', () => {
   it('applies success color classes', () => {
     const { container } = render(<Badge label="Success" color="success" />);
     const badge = container.firstChild as HTMLElement;
-    expect(badge.className).toContain('bg-emerald-500-bg');
+    expect(badge.className).toContain('bg-emerald-50');
     expect(badge.className).toContain('text-emerald-500');
   });
 
   it('applies warning color classes', () => {
     const { container } = render(<Badge label="Warning" color="warning" />);
     const badge = container.firstChild as HTMLElement;
-    expect(badge.className).toContain('bg-amber-500-bg');
+    expect(badge.className).toContain('bg-amber-50');
     expect(badge.className).toContain('text-amber-500');
   });
 
   it('applies danger color classes', () => {
     const { container } = render(<Badge label="Error" color="danger" />);
     const badge = container.firstChild as HTMLElement;
-    expect(badge.className).toContain('bg-red-500-bg');
+    expect(badge.className).toContain('bg-red-50');
     expect(badge.className).toContain('text-red-500');
   });
 

--- a/src/shared/ui/__tests__/LoadingSpinner.test.tsx
+++ b/src/shared/ui/__tests__/LoadingSpinner.test.tsx
@@ -52,7 +52,7 @@ describe('LoadingSpinner', () => {
     const { container } = render(<LoadingSpinner />);
     const spinner = container.querySelector('.animate-spin') as HTMLElement;
     expect(spinner.className).toContain('border-blue-200');
-    expect(spinner.className).toContain('border-t-primary-600');
+    expect(spinner.className).toContain('border-t-blue-600');
   });
 
   it('applies white color classes', () => {


### PR DESCRIPTION
## Summary                                                                                                                                    
                                                                                                                                              
  재테스트 리포트 2026-04-21 에 기록된 29개 이슈(Critical 8 / High 13 / Medium 6 / Low 2) + 스캔 중 발견한 Blue Design System 토큰 누수 일괄    
  정리.
                                                                                                                                                
  - **Critical 8 (런치 차단)** 전부 해결: 공고 등록 CTA 데드버튼, 이력서 저장 422, 지원하기 무반응, /jobs SSR 에러, 이력서 편집 prefill,        
  /user/profile hydration, /api/me 401 루프, 기업 카드 클릭                                                                                     
  - **High 13 / Medium 6 / Low 2** 중 클라이언트 범위 전부 처리 — 나머지는 서버 의존 (ISSUE-119/121/122)으로 graceful fallback 적용             
  - CSS 버그 40+ 파일 일괄 교체 (무효 클래스로 투명/기본색 렌더되던 요소들 복구)                                                                
                                                                                                                                                
  ## 주요 변경점                                                                                                                                
                                                                                                                                                
  ### 🔴 Critical 8 — ISSUE-101~108                                                                                                             
  | 커밋 | 이슈 | 핵심 |                                          
  |---|---|---|                                                                                                                                 
  | `a1f2dce` | 107 | refresh token **single-flight + max 3회** 재시도 (기존 20+회 루프 차단) |
  | `f9aa2d4` | 106 | `/user/profile` refetchOnWindowFocus=false + 8초 타임아웃 + visibilitychange 복구 |                                       
  | `07e81eb` | 101 | 기업 대시보드 4개 CTA `handleCreateJob` 콜백 통일 + `type="button"` |                                                     
  | `7a08332` | 108 | 대시보드 마감 카드 + `/company/jobs` 카드 루트 onClick/키보드/role |                                                      
  | `1268f8a` | 103 | `applyToJob` stub → 실제 `POST /api/applications` 호출, 409 중복 방지, mutation.isSuccess 로 "지원 완료" 상태 |           
  | `4195b09` | 105 | `ResumeEditor` async prefill: `buildFormDefaults()` + `reset()` useEffect |                                               
  | `1006c7f` | 102 | 빈 배열 row sanitize + 422 detail 파싱해 필드별 토스트 |                                                                  
  | `b859a02` | 104 | `normalizeCompanyPost()` 로 null 필드 정규화 + id 필터링 |                                                                
                                                                                                                                                
  ### 🎨 CSS 토큰 정리 — `535cd34`                                                                                                              
  Blue Design System 전환에서 남은 무효 Tailwind 클래스 40+ 파일 일괄 교체:                                                                     
  - `bg-red-500-bg0` → `bg-red-500`  (D-N 긴급 배지, 삭제 버튼 solid 복구)                                                                      
  - `bg-{red,emerald,amber}-500-bg` → `bg-{red,emerald,amber}-50`                                                                               
  - `border-{red,emerald,amber}-500-bg` → `border-{red,emerald,amber}-{100,200}`                                                                
  - `text-white0` → `text-slate-500`  (CompanyProfileClient 10곳)                                                                               
  - `from/to/via/bg/text/border/ring-primary-{N}` → `blue-{N}`                                                                                  
                                                                                                                                                
  ### 🟠 High — ISSUE-110~121                                                                                                                   
  - `c9ca45b` **111**: `mockMyProfile` 완전 제거, 하드코딩 이메일(`jieun.lee@example.com`) 삭제                                                 
  - `c9ca45b` **112**: `CompanyProfileResponse.company_name?` optional 추가, "기업 #1" → `company_name || "내 회사"` fallback                   
  - `ab7a34c` **114**: `isPostExpired()` 유틸 — `start==end` 시드 데이터는 마감 처리 안 함                                                      
  - `ab7a34c` **118**: `formatDateRange()`/`formatDateShort()` — ISO raw 문자열 노출 제거                                                       
  - `ab7a34c` **124**: 진단 결과 추천 공고에서 활성 공고만 필터                                                                                 
  - `17ec8d5` **117**: `/company/posts/edit/{id}` 가드에 `cookieManager.getUserType()` fallback                                                 
  - `17ec8d5` **129**: `/company/profile` 라우트 추가 (→ /edit 리다이렉트)                                                                      
  - `17ec8d5` **110**: `/user/{resume,diagnosis,settings}` 리다이렉트 페이지 + `/user/bookmarks`, `/user/applications` 최소 UI (404 graceful)   
                                                                                                                                                
  ### 🟡 Medium — ISSUE-122~127                                                                                                                 
  - `a1f2dce` **126**: refresh 재시도 제한 (107 에 포함 처리)                                                                                   
  - `dc4155b` **123**: 진단 결과 CTA `authLoading` 동안 렌더 지연                                                                               
  - `dc4155b` **127**: HeroSection 로그인 상태 반영 — `welcomeBack` + `goToDashboard`                                                           
  - **125 (토스트)**: 프로필/이력서/진단 주요 mutation onSuccess 이미 구현됨 — 확인만                                                           
                                                                                                                                                
  ### 🟢 Low — ISSUE-128, 129                                                                                                                   
  - **128 (KO/EN 대소문자)**: `LanguageToggle` 이미 CSS `uppercase` 로 일관 표시 — 확인만                                                       
                                                                                                                                                
  ### 🔧 서버 의존 이슈 — `d47dc3c` (클라 방어)                                                                                                 
  - **113 ("string" placeholder)**: `cleanPlaceholder()` 로 `"string"`/`"010-0101-0101"` 패턴 필터링 + `isPlaceholder()` 검증 추가              
  - **115 (/company/applicants)**: "준비 중" 단순 메시지 → 예정 기능 리스트 + 대체 CTA                                                          
  - **116 (/company/settings)**: 프로필 편집 링크를 일급 액션으로 노출 + 예정 기능 표시                                                         
                                                                                                                                                
  ### 🌐 i18n — `6231345`                                                                                                                       
  - **120**: `Footer.tsx` 하드코딩 한국어 링크 → `useTranslations('common.footer')`                                                             
    - `jobsLink`, `supportLink` 키 ko/en 추가                                                                                                   
    - 저작권 연도 `new Date().getFullYear()` 동적 처리                                                                                          
                                                                                                                                                
  ## 알려진 제약 (서버 구현 필요)                                                                                                               
                                                                                                                                                
  | 이슈 | 상태 |                                                                                                                               
  |---|---|                                                       
  | ISSUE-119 (limit 무시) | 서버 페이지네이션 필요. 클라 placeholder keep |                                                                    
  | ISSUE-121 (`/api/applications/me` 404) | `/user/applications` 에서 404 시 "준비 중" UI 표시 중 |                                            
  | ISSUE-122 (진단 점수 로직) | 서버 scoring 검증 필요 |                                                                                       
  | refresh token `.workinkorea` 도메인 | 쿠키 도메인 이슈 — 본 PR 에서는 루프만 차단. 근본 원인은 별도 티켓 |                                  
                                                                                                                                                
  ## Test plan                                                                                                                                  
  - [ ] `npm run build` 성공 (30+ 라우트 컴파일) — ✅ 확인됨                                                                                    
  - [ ] `npx tsc --noEmit` 통과 — ✅ 확인됨                                                                                                     
  - [ ] `npx vitest run src/` 793/793 통과 — ✅ 확인됨                                                                                          
  - [ ] 개인 로그인 → `/user/profile` 즉시 렌더 + "jieun.lee" 미표시                                                                            
  - [ ] 기업 로그인 → 대시보드 4개 CTA 모두 `/company/posts/create` 진입                                                                        
  - [ ] 기업 대시보드 → 공고 카드 클릭 시 편집 페이지 진입 (진행중/마감 모두)                                                                   
  - [ ] `/jobs` 페이지 렌더 오류 없음 (null 날짜 공고 포함)                                                                                     
  - [ ] 이력서 편집 페이지 → 기존 값 prefill 확인                                                                                               
  - [ ] 이력서 저장 → 빈 필드 자동 제외, 422 시 필드별 토스트                                                                                   
  - [ ] 공고 상세 "지원하기" → 이력서 선택 모달 → 지원 완료 상태 표시                                                                           
  - [ ] 로그인 상태로 랜딩 방문 시 "시작하기" 대신 "대시보드로 이동" 표시                                                                       
  - [ ] KO/EN 토글 시 푸터 링크 번역됨                                                                                                          
  - [ ] `/company/profile` 접근 시 `/company/profile/edit` 리다이렉트                                                                           
  - [ ] `/user/bookmarks` localStorage 북마크 목록 표시                                                                                         
  - [ ] 모바일 (iPhone SE) / 태블릿 (iPad) / 데스크톱 반응형 확인