### PR TITLE
fix(jobs): gracefully degrade SSR fetch failure to empty list

### DIFF
--- a/e2e/anonymous/public-pages.anon.spec.ts
+++ b/e2e/anonymous/public-pages.anon.spec.ts
@@ -3,7 +3,9 @@ import { PUBLIC_ROUTES } from '../fixtures/test-data';
 import { filterAppErrors } from '../helpers/console';
 
 test.describe('Public pages smoke', () => {
-  // /jobs: production Server Components render error — tracked, currently fixme
+  // /jobs: SSR 실패 시 error.tsx 가 console.error 를 발생시켜 본 테스트를 실패시켰던 이슈.
+  // 현재 소스 fix 완료 (src/features/jobs/api/postsApi.ts — SSR 실패 시 empty fallback).
+  // 프로덕션 deploy 후 아래 fixme 를 제거하고 일반 test 로 전환하면 됨.
   for (const route of PUBLIC_ROUTES) {
     const runner = route === '/jobs' ? test.fixme : test;
     runner(`${route} 은 200 응답 + <h1> 렌더 + app-level console error 없음`, async ({ page, consoleErrors }) => {

--- a/src/features/jobs/api/__tests__/postsApi.test.ts
+++ b/src/features/jobs/api/__tests__/postsApi.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/shared/api/fetchClient', async () => {
+  const actual = await vi.importActual<typeof import('@/shared/api/fetchClient')>(
+    '@/shared/api/fetchClient',
+  );
+  return {
+    ...actual,
+    fetchAPI: vi.fn(),
+  };
+});
+
+import { fetchAPI, FetchError } from '@/shared/api/fetchClient';
+import { getCompanyPosts } from '@/features/jobs/api/postsApi';
+
+const mockedFetchAPI = vi.mocked(fetchAPI);
+
+describe('getCompanyPosts — graceful degradation (prod SSR fallback)', () => {
+  beforeEach(() => {
+    mockedFetchAPI.mockReset();
+  });
+
+  it('정상 응답을 받으면 posts 를 반환한다', async () => {
+    mockedFetchAPI.mockResolvedValueOnce({
+      company_posts: [
+        { id: 1, title: 't1', salary: 3000 },
+      ],
+      pagination: { skip: 0, limit: 12, count: 1 },
+    });
+
+    const res = await getCompanyPosts(1);
+
+    expect(res.company_posts).toHaveLength(1);
+    expect(res.company_posts[0].id).toBe(1);
+  });
+
+  it('404 FetchError 는 빈 결과를 반환한다 (기존 동작)', async () => {
+    mockedFetchAPI.mockRejectedValueOnce(new FetchError('Not Found', 404));
+
+    const res = await getCompanyPosts(1);
+
+    expect(res.company_posts).toEqual([]);
+    expect(res.total).toBe(0);
+  });
+
+  it('네트워크 에러(status 0) 는 SSR 실패 → 빈 결과 반환 (클라이언트 훅이 재시도)', async () => {
+    mockedFetchAPI.mockRejectedValueOnce(new FetchError('Network request failed', 0));
+
+    const res = await getCompanyPosts(1);
+
+    expect(res.company_posts).toEqual([]);
+    expect(res.total).toBe(0);
+  });
+
+  it('5xx FetchError 는 SSR 실패 → 빈 결과 반환', async () => {
+    mockedFetchAPI.mockRejectedValueOnce(new FetchError('Bad Gateway', 502));
+
+    const res = await getCompanyPosts(1);
+
+    expect(res.company_posts).toEqual([]);
+    expect(res.total).toBe(0);
+  });
+
+  it('401 FetchError 도 SSR 실패 → 빈 결과 반환 (공개 엔드포인트라 익명 호출이 401 받으면 설정 오류)', async () => {
+    mockedFetchAPI.mockRejectedValueOnce(new FetchError('Unauthorized', 401));
+
+    const res = await getCompanyPosts(1);
+
+    expect(res.company_posts).toEqual([]);
+  });
+
+  it('일반 Error (FetchError 가 아닌 예외) 도 빈 결과 반환', async () => {
+    mockedFetchAPI.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    const res = await getCompanyPosts(1);
+
+    expect(res.company_posts).toEqual([]);
+  });
+});

--- a/src/features/jobs/api/postsApi.ts
+++ b/src/features/jobs/api/postsApi.ts
@@ -110,12 +110,12 @@ export async function getCompanyPosts(
       total_pages: isLastPage ? page : page + 1,
     };
   } catch (err) {
-    // 404는 "공개 목록 엔드포인트 미구현" 상태로 간주 → 빈 목록 반환
-    // (EmptyState UI 표시). 5xx 및 기타 오류는 상위로 전파하여 error.tsx 에서 처리.
-    if (err instanceof FetchError && err.status === 404) {
-      return { company_posts: [], total: 0, page: 1, limit, total_pages: 0 };
-    }
-    throw err;
+    // SSR 실패는 모두 "빈 결과" 로 치환한다. 클라이언트의 useCompanyPosts 훅이
+    // 빈 initialData 를 감지하면 rewrite 경로(/api/*)로 다시 호출하므로, SSR
+    // 경로(SERVER_API_URL 직통)가 실패해도 UX 가 자연스럽게 복구된다.
+    // error.tsx 대신 empty state 가 먼저 보이고, 클라이언트 재시도 결과가 덮어씀.
+    console.error('[getCompanyPosts] SSR fetch failed, falling back to empty:', err);
+    return { company_posts: [], total: 0, page: 1, limit, total_pages: 0 };
   }
 }
 


### PR DESCRIPTION
## 문제                                                                       
  
  `/jobs` 프로덕션에서 Server Components render error 발생 → `error.tsx` 의     
  "공고 목록을 불러올 수 없습니다" 표시. E2E 리그레션 가드에서 `console.error`
  캐치되어 테스트 실패.                                                         
                                                                  
  ## 원인                                                                     

  - `getCompanyPosts()` 의 SSR 경로는 `SERVER_API_URL` (Docker 내부) 직통       
  - 프로덕션 SSR 경로에서 간헐적 실패(네트워크/5xx) → 404 외 에러 전부 상위 전파
   → `error.tsx` 렌더                                                           
  - 외부에서 `curl https://workinkorea.net/api/posts/company/list` 는 200 정상 →
   rewrite 경로는 살아있음                                                      
                                                                                
  ## 수정                                                         
                                                                                
  `getCompanyPosts()` 에서 모든 fetch 실패를 catch 하여 빈 리스트 반환. 서버
  로그로만 기록.                                                                
                
  이미 `useCompanyPosts` 훅은 빈 initialData 감지 시 클라이언트 쿼리로 자동     
  재시도 (`isEmptyInitialData`). SSR 실패해도 rewrite 경로로 복구됨.            
                                                                              
  | 시나리오 | Before | After |                                                 
  |---|---|---|                                                                 
  | SSR 성공 | ✅ hydrated data | ✅ 동일 |                                   
  | SSR 실패 (5xx/network) | ❌ error.tsx | ✅ 짧은 empty flash → 클라이언트    
  fetch 성공 → posts 렌더 |                                                     
  | 실제 데이터 없음 (404) | ✅ empty state | ✅ 동일 |                         
                                                                                
  ## 검증                                                                       
                                                                                
  **신규 테스트**: `src/features/jobs/api/__tests__/postsApi.test.ts`         
  - 200 정상 / 404 / network(0) / 401 / 502 / TypeError — 6 케이스 모두 empty   
  fallback 검증                                                              
  - 6/6 pass                                                                    
            
  **기존 테스트 무영향**: typecheck 통과, anonymous E2E 12 passed / 2 skipped   
  (기존과 동일)                                                                 
                                                                              
  ## Follow-up (merge & deploy 후)                                              
                                                                                
  `e2e/anonymous/public-pages.anon.spec.ts` 에서 `/jobs` fixme 제거하고 일반  
  `test` 로 전환 → 리그레션 가드 활성화. 1-line 변경.