### PR TITLE
 Fix: use 'all' as default filter value to prevent empty list

### DIFF
--- a/e2e/anonymous/public-pages.anon.spec.ts
+++ b/e2e/anonymous/public-pages.anon.spec.ts
@@ -3,12 +3,8 @@ import { PUBLIC_ROUTES } from '../fixtures/test-data';
 import { filterAppErrors } from '../helpers/console';
 
 test.describe('Public pages smoke', () => {
-  // /jobs: SSR 실패 시 error.tsx 가 console.error 를 발생시켜 본 테스트를 실패시켰던 이슈.
-  // 현재 소스 fix 완료 (src/features/jobs/api/postsApi.ts — SSR 실패 시 empty fallback).
-  // 프로덕션 deploy 후 아래 fixme 를 제거하고 일반 test 로 전환하면 됨.
   for (const route of PUBLIC_ROUTES) {
-    const runner = route === '/jobs' ? test.fixme : test;
-    runner(`${route} 은 200 응답 + <h1> 렌더 + app-level console error 없음`, async ({ page, consoleErrors }) => {
+    test(`${route} 은 200 응답 + <h1> 렌더 + app-level console error 없음`, async ({ page, consoleErrors }) => {
       const resp = await page.goto(route);
       expect(resp, `no response for ${route}`).not.toBeNull();
       expect(resp!.status(), `status for ${route}`).toBeLessThan(400);
@@ -18,6 +14,15 @@ test.describe('Public pages smoke', () => {
       expect(appErrors, `console errors on ${route}`).toEqual([]);
     });
   }
+
+  test('/jobs 는 공고 카드를 1개 이상 렌더한다 (필터 default mismatch 리그레션 가드)', async ({ page }) => {
+    await page.goto('/jobs');
+    // 공고 카드 링크 `/jobs/{id}` 가 최소 1개 이상 존재
+    const cardLinks = page.locator('a[href^="/jobs/"]').filter({ hasNot: page.locator('a[href="/jobs"]') });
+    await expect(cardLinks.first()).toBeVisible({ timeout: 15_000 });
+    const count = await cardLinks.count();
+    expect(count, '공고 카드 개수').toBeGreaterThan(0);
+  });
 
   test('footer 주요 링크 (/jobs, /terms, /privacy, /support, /faq) 가 200 응답', async ({ page, request }) => {
     await page.goto('/');

--- a/src/app/(main)/jobs/page.tsx
+++ b/src/app/(main)/jobs/page.tsx
@@ -20,7 +20,7 @@ export default async function JobsPage({
       initialData={initialData}
       currentPage={currentPage}
       initialQ={params.q || ''}
-      initialType={params.type || '전체'}
+      initialType={params.type || 'all'}
       initialSort={params.sort || 'latest'}
     />
   );


### PR DESCRIPTION
## 원인                                                                       
         
  `/jobs` 페이지가 "검색 결과 0개" empty state 로 렌더되던 문제. Server         
  Components render error 수정(PR #123) 배포 후 확인되니 별도의 pre-existing    
  버그가 드러남.                                                              
                                                                                
  - `src/app/(main)/jobs/page.tsx:23` — `initialType={params.type || '전체'}` 로
   한국어 label 값 전달                                                         
  - `JobsListView` 내부는 `'all'` 을 value 로 사용 (`EMPLOYMENT_TYPES[0]` → `{
  value: 'all', label: t('all') }` = "전체")                                    
  - `isFiltered = selectedType !== 'all' || ...` → `selectedType = '전체'` 이면 
  항상 true                                                                    
  - `result.filter(p => p.employment_type === '전체')` → 매칭 0건               
                                                                  
  즉 **value 와 label 혼동**. URL에 `?type=` 없이 `/jobs` 들어오면 자동 필터링  
  상태로 진입 → 전 공고 사라짐.                                                 
                                                                                
  ## 수정                                                                       
                                                                              
  page.tsx 의 default 를 `'all'` 로 변경 (1 line).                            
                                                                                
  ## 리그레션 가드
                                                                                
  E2E 에 공고 카드 ≥1 렌더 검증 추가:                             
  ```ts                                                                         
  test('/jobs 는 공고 카드를 1개 이상 렌더한다 (필터 default mismatch 리그레션
  가드)', ...);                                                                 
                                                                                
  /jobs fixme 제거 — SSR 에러는 PR #123 배포로 해결, 본 PR 로 empty list 도   
  해결되므로 이제 일반 test 로 관리.                                            
                                                                  
  Test Plan                                                                     
                                                                  
  - typecheck + lint 통과                                                       
  - Playwright test discovery 확인
  - merge + deploy 후 npm run test:e2e:pw:anon 녹색 (특히 /jobs + 새 카드 렌더  
  테스트)  