### PR TITLE
Feat: 기업 라우트 분리 + 헤더 토글/버튼 UI 픽스

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -113,8 +113,8 @@ function routeGuard(request: NextRequest): NextResponse {
   }
 
   // Company routes
-  // /company (exact) is public — shows landing or dashboard depending on auth
-  // /company/* sub-routes require company auth
+  // /company (exact) is the public landing page
+  // /company/* sub-routes (including /company/dashboard) require company auth
   if (pathname.startsWith('/company/')) {
     if (!userType) {
       const loginUrl = new URL('/company-login', request.url);
@@ -157,7 +157,7 @@ function getDashboardUrl(userType: UserType): string {
     case 'admin':
       return '/admin';
     case 'company':
-      return '/company';
+      return '/company/dashboard';
     case 'user':
       return '/user/profile';
     default:

--- a/src/app/(main)/company/applicants/page.tsx
+++ b/src/app/(main)/company/applicants/page.tsx
@@ -36,7 +36,7 @@ export default function ApplicantsPage() {
 
           <div className="flex flex-col sm:flex-row gap-3 justify-center">
             <Link
-              href="/company"
+              href="/company/dashboard"
               className="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg text-body-3 font-semibold hover:bg-blue-700 transition-colors"
             >
               대시보드로 돌아가기

--- a/src/app/(main)/company/dashboard/loading.tsx
+++ b/src/app/(main)/company/dashboard/loading.tsx
@@ -1,0 +1,71 @@
+import { Skeleton } from '@/shared/ui/Skeleton';
+
+function PostCardSkeleton() {
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-4 sm:p-6">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex-1 space-y-2">
+          <Skeleton variant="text" className="h-5 w-3/4" />
+          <div className="flex flex-wrap gap-2">
+            <Skeleton variant="text" className="h-3 w-24" />
+            <Skeleton variant="text" className="h-3 w-16" />
+          </div>
+          <Skeleton variant="text" className="h-3 w-32" />
+          <Skeleton variant="text" className="h-3 w-40" />
+        </div>
+        <div className="flex flex-col gap-2 items-end shrink-0">
+          <Skeleton variant="text" className="h-6 w-16 rounded-full" />
+          <Skeleton className="h-8 w-16 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function CompanyLoading() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* 기업 정보 헤더 */}
+      <div className="bg-white border-b border-slate-100 px-4 sm:px-6 py-5 sm:py-6">
+        <div className="page-container">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex items-center gap-4">
+              <Skeleton className="w-14 h-14 rounded-xl shrink-0" />
+              <div className="space-y-2">
+                <Skeleton variant="text" className="h-3 w-20" />
+                <Skeleton variant="text" className="h-6 w-40" />
+              </div>
+            </div>
+            <Skeleton className="h-10 w-36 rounded-lg" />
+          </div>
+
+          {/* 탭 네비게이션 */}
+          <div className="flex gap-1 mt-5 border-b border-slate-100">
+            {['관리 중인 공고', '기업 정보'].map((tab, i) => (
+              <div
+                key={tab}
+                className={`flex items-center gap-1.5 px-4 py-3 ${i === 0 ? 'border-b-2 border-blue-600' : ''}`}
+              >
+                <Skeleton variant="circle" className="w-4 h-4" />
+                <Skeleton variant="text" className={`h-4 ${i === 0 ? 'w-24' : 'w-16'}`} />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* 탭 콘텐츠: 공고 목록 */}
+      <div className="page-container py-6 sm:py-8 space-y-5">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="text" className="h-5 w-28" />
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <PostCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/company/dashboard/page.tsx
+++ b/src/app/(main)/company/dashboard/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react';
+import { Metadata } from 'next';
+import { createMetadata } from '@/shared/lib/metadata';
+import CompanyProfileClient from '@/features/company/pages/CompanyProfileClient';
+import { CompanyDashboardSkeleton } from '@/shared/ui/SkeletonCards';
+
+export const metadata: Metadata = createMetadata({
+  title: '기업 대시보드 - WorkInKorea',
+  description: '채용 공고와 지원자 현황을 한눈에 관리하세요.',
+});
+
+export default function CompanyDashboardPage() {
+  return (
+    <Suspense fallback={<CompanyDashboardSkeleton />}>
+      <CompanyProfileClient />
+    </Suspense>
+  );
+}

--- a/src/app/(main)/company/loading.tsx
+++ b/src/app/(main)/company/loading.tsx
@@ -1,69 +1,28 @@
 import { Skeleton } from '@/shared/ui/Skeleton';
 
-function PostCardSkeleton() {
+export default function CompanyLandingLoading() {
   return (
-    <div className="bg-white border border-slate-200 rounded-xl p-4 sm:p-6">
-      <div className="flex items-start justify-between gap-3 mb-3">
-        <div className="flex-1 space-y-2">
-          <Skeleton variant="text" className="h-5 w-3/4" />
-          <div className="flex flex-wrap gap-2">
-            <Skeleton variant="text" className="h-3 w-24" />
-            <Skeleton variant="text" className="h-3 w-16" />
-          </div>
-          <Skeleton variant="text" className="h-3 w-32" />
-          <Skeleton variant="text" className="h-3 w-40" />
-        </div>
-        <div className="flex flex-col gap-2 items-end shrink-0">
-          <Skeleton variant="text" className="h-6 w-16 rounded-full" />
-          <Skeleton className="h-8 w-16 rounded-lg" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-export default function CompanyLoading() {
-  return (
-    <div className="min-h-screen bg-slate-50">
-      {/* 기업 정보 헤더 */}
-      <div className="bg-white border-b border-slate-100 px-4 sm:px-6 py-5 sm:py-6">
-        <div className="page-container">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <div className="flex items-center gap-4">
-              <Skeleton className="w-14 h-14 rounded-xl shrink-0" />
-              <div className="space-y-2">
-                <Skeleton variant="text" className="h-3 w-20" />
-                <Skeleton variant="text" className="h-6 w-40" />
-              </div>
+    <div className="min-h-screen bg-slate-100">
+      <div className="max-w-[1100px] mx-auto px-6 py-6">
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_260px] gap-5">
+          <div className="space-y-5">
+            <Skeleton className="h-24 rounded-xl" />
+            <div className="space-y-2">
+              <Skeleton variant="text" className="h-5 w-48" />
+              <Skeleton variant="text" className="h-3 w-64" />
             </div>
-            <Skeleton className="h-10 w-36 rounded-lg" />
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-32 rounded-xl" />
+              ))}
+            </div>
+            <Skeleton className="h-44 rounded-xl" />
           </div>
-
-          {/* 탭 네비게이션 */}
-          <div className="flex gap-1 mt-5 border-b border-slate-100">
-            {['관리 중인 공고', '기업 정보'].map((tab, i) => (
-              <div
-                key={tab}
-                className={`flex items-center gap-1.5 px-4 py-3 ${i === 0 ? 'border-b-2 border-blue-600' : ''}`}
-              >
-                <Skeleton variant="circle" className="w-4 h-4" />
-                <Skeleton variant="text" className={`h-4 ${i === 0 ? 'w-24' : 'w-16'}`} />
-              </div>
-            ))}
+          <div className="space-y-4">
+            <Skeleton className="h-40 rounded-xl" />
+            <Skeleton className="h-32 rounded-xl" />
+            <Skeleton className="h-40 rounded-xl" />
           </div>
-        </div>
-      </div>
-
-      {/* 탭 콘텐츠: 공고 목록 */}
-      <div className="page-container py-6 sm:py-8 space-y-5">
-        <div className="flex items-center justify-between">
-          <Skeleton variant="text" className="h-5 w-28" />
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <PostCardSkeleton key={i} />
-          ))}
         </div>
       </div>
     </div>

--- a/src/app/(main)/company/page.tsx
+++ b/src/app/(main)/company/page.tsx
@@ -1,29 +1,12 @@
-import { Suspense } from 'react';
-import { cookies } from 'next/headers';
 import { Metadata } from 'next';
 import { createMetadata } from '@/shared/lib/metadata';
-import CompanyProfileClient from '@/features/company/pages/CompanyProfileClient';
 import { CompanyLandingPage } from '@/features/company/pages/CompanyLandingPage';
-import { CompanyDashboardSkeleton } from '@/shared/ui/SkeletonCards';
 
 export const metadata: Metadata = createMetadata({
   title: '기업 채용 - WorkInKorea',
   description: '외국인 인재를 채용하고 싶은 기업을 위한 글로벌 채용 플랫폼입니다.',
 });
 
-export default async function CompanyPage() {
-  const cookieStore = await cookies();
-  const userType = cookieStore.get('userType')?.value;
-
-  // 기업 회원으로 로그인된 경우 → 대시보드
-  if (userType === 'company') {
-    return (
-      <Suspense fallback={<CompanyDashboardSkeleton />}>
-        <CompanyProfileClient />
-      </Suspense>
-    );
-  }
-
-  // 비로그인 또는 다른 유형 → 기업 랜딩 페이지
+export default function CompanyPage() {
   return <CompanyLandingPage />;
 }

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -89,7 +89,7 @@ export const authApi = {
    * 기업 로그인
    *
    * 서버 응답 형식:
-   * - 200: { "url": "/company" } (성공)
+   * - 200: { "url": "/company/dashboard" } (성공)
    * - 401: { "url": "/company-login" } (인증 실패)
    * - 500: { "url": "/company-login" } (서버 오류)
    *
@@ -149,7 +149,7 @@ export const authApi = {
       return url;
     }
 
-    return '/company';
+    return '/company/dashboard';
   },
 
   /**

--- a/src/features/auth/components/BusinessLoginForm.tsx
+++ b/src/features/auth/components/BusinessLoginForm.tsx
@@ -6,7 +6,7 @@ import { useForm } from 'react-hook-form';
 import { FormField } from '@/shared/ui/FormField';
 import { Input } from '@/shared/ui/Input';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { validatePassword } from '@/shared/lib/utils/validation';
 import { authApi } from '@/features/auth/api/authApi';
 import { useAuth } from '@/features/auth/hooks/useAuth';
@@ -67,6 +67,7 @@ const fadeUp = {
 
 export default function BusinessLoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { login } = useAuth();
   const t = useTranslations('auth.companyLogin');
   const [showPassword, setShowPassword] = useState(false);
@@ -149,8 +150,18 @@ export default function BusinessLoginForm() {
         } else {
           localStorage.removeItem(SAVED_EMAIL_KEY);
         }
-        const safeUrl = isValidCallbackUrl(responseUrl) ? responseUrl : '/';
-        window.location.href = safeUrl;
+        // Redirect priority:
+        // 1) ?callbackUrl=... (deep link from middleware on protected route)
+        // 2) backend responseUrl (specific post-login destination, ignore generic '/')
+        // 3) /company dashboard (default for company users)
+        const callbackUrl = searchParams.get('callbackUrl');
+        const finalUrl =
+          callbackUrl && isValidCallbackUrl(callbackUrl)
+            ? callbackUrl
+            : isValidCallbackUrl(responseUrl) && responseUrl !== '/'
+              ? responseUrl
+              : '/company/dashboard';
+        window.location.href = finalUrl;
       } else {
         throw new Error('Invalid response from server');
       }

--- a/src/features/auth/components/BusinessSignupComponent.tsx
+++ b/src/features/auth/components/BusinessSignupComponent.tsx
@@ -246,7 +246,7 @@ export default function BusinessSignupComponent({ callbackUrl }: { callbackUrl?:
       await authApi.companyLogin({ username: data.email, password: data.password });
       login('company');
       toast.success(t('toastSuccess'));
-      router.push(callbackUrl || '/company');
+      router.push(callbackUrl || '/company/dashboard');
     } catch (error: unknown) {
       logError(error, 'BusinessSignupComponent.onSubmit');
       const rawMessage = extractErrorMessage(error, '');

--- a/src/features/company/pages/CompanyLandingPage.tsx
+++ b/src/features/company/pages/CompanyLandingPage.tsx
@@ -10,9 +10,11 @@ import {
   Building2,
   CheckCircle2,
   ArrowRight,
+  LayoutDashboard,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/shared/lib/utils/utils';
+import { useAuth } from '@/features/auth/hooks/useAuth';
 
 const fadeUp = {
   hidden:  { opacity: 0, y: 16 },
@@ -25,6 +27,8 @@ const fadeUp = {
 
 export function CompanyLandingPage() {
   const t = useTranslations('company.landing');
+  const { isAuthenticated, userType } = useAuth();
+  const isCompanyUser = isAuthenticated && userType === 'company';
 
   const services = [
     {
@@ -171,36 +175,57 @@ export function CompanyLandingPage() {
           {/* ── 우측 사이드바 ──────────────────────────────────────────── */}
           <div className="space-y-4">
 
-            {/* 로그인/회원가입 카드 */}
+            {/* 로그인/회원가입 카드 — 인증된 기업 사용자는 대시보드 바로가기로 대체 */}
             <motion.div
               initial={{ opacity: 0, x: 12 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ delay: 0.15 }}
               className="bg-white border border-slate-200 rounded-xl p-5"
             >
-              <p className="text-body-3 font-extrabold text-slate-900 mb-0.5">{t('sidebarWelcome')}</p>
-              <p className="text-caption-2 text-slate-400 mb-4">{t('sidebarLoginHint')}</p>
-              <div className="flex gap-2">
-                <Link
-                  href="/company-login"
-                  style={{ color: '#ffffff' }}
-                  className={cn(
-                    'flex-1 py-2.5 bg-blue-600 text-white text-caption-1 font-bold rounded-lg text-center',
-                    'hover:bg-blue-700 transition-colors cursor-pointer',
-                  )}
-                >
-                  {t('login')}
-                </Link>
-                <Link
-                  href="/company-signup"
-                  className={cn(
-                    'flex-1 py-2.5 border border-slate-200 text-slate-600 text-caption-1 font-semibold rounded-lg text-center',
-                    'hover:bg-slate-50 transition-colors cursor-pointer',
-                  )}
-                >
-                  {t('signup')}
-                </Link>
-              </div>
+              {isCompanyUser ? (
+                <>
+                  <p className="text-body-3 font-extrabold text-slate-900 mb-0.5">대시보드</p>
+                  <p className="text-caption-2 text-slate-400 mb-4">공고와 지원자 현황을 확인하세요</p>
+                  <Link
+                    href="/company/dashboard"
+                    style={{ color: '#ffffff' }}
+                    className={cn(
+                      'flex items-center justify-center gap-1.5 w-full py-2.5',
+                      'bg-blue-600 text-caption-1 font-bold rounded-lg text-white',
+                      'hover:bg-blue-700 transition-colors cursor-pointer',
+                    )}
+                  >
+                    <LayoutDashboard size={14} />
+                    대시보드로 가기
+                  </Link>
+                </>
+              ) : (
+                <>
+                  <p className="text-body-3 font-extrabold text-slate-900 mb-0.5">{t('sidebarWelcome')}</p>
+                  <p className="text-caption-2 text-slate-400 mb-4">{t('sidebarLoginHint')}</p>
+                  <div className="flex gap-2">
+                    <Link
+                      href="/company-login"
+                      style={{ color: '#ffffff' }}
+                      className={cn(
+                        'flex-1 py-2.5 bg-blue-600 text-caption-1 font-bold rounded-lg text-center text-white',
+                        'hover:bg-blue-700 transition-colors cursor-pointer',
+                      )}
+                    >
+                      {t('login')}
+                    </Link>
+                    <Link
+                      href="/company-signup"
+                      className={cn(
+                        'flex-1 py-2.5 border border-slate-200 text-slate-600 text-caption-1 font-semibold rounded-lg text-center',
+                        'hover:bg-slate-50 transition-colors cursor-pointer',
+                      )}
+                    >
+                      {t('signup')}
+                    </Link>
+                  </div>
+                </>
+              )}
             </motion.div>
 
             {/* 빠른 메뉴 */}

--- a/src/features/company/pages/CompanyProfileClient.tsx
+++ b/src/features/company/pages/CompanyProfileClient.tsx
@@ -58,7 +58,7 @@ const CompanyProfileClient = () => {
   useEffect(() => {
     if (searchParams.get('redirected') === '1') {
       toast.error('해당 페이지에 접근 권한이 없습니다.');
-      router.replace('/company', { scroll: false });
+      router.replace('/company/dashboard', { scroll: false });
     }
   }, [searchParams, router]);
 
@@ -303,9 +303,10 @@ const CompanyProfileClient = () => {
                   <button
                     type="button"
                     onClick={handleCreateJob}
+                    style={{ color: '#ffffff' }}
                     className={cn(
                       'inline-flex items-center gap-1.5 px-3 py-1.5',
-                      'bg-blue-600 text-white text-caption-2 font-semibold rounded-lg',
+                      'bg-blue-600 text-caption-2 font-semibold rounded-lg text-white',
                       'hover:bg-blue-700 transition-colors cursor-pointer',
                     )}
                   >

--- a/src/features/company/pages/CompanyProfileEditClient.tsx
+++ b/src/features/company/pages/CompanyProfileEditClient.tsx
@@ -108,7 +108,7 @@ const CompanyProfileEditClient = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['companyProfile'] });
       toast.success(profile ? t('updateSuccess') : t('createSuccess'));
-      setTimeout(() => router.push('/company'), 1000);
+      setTimeout(() => router.push('/company/dashboard'), 1000);
     },
     onError: (error: unknown) => {
       logError(error, 'CompanyProfileEditClient.updateProfile');

--- a/src/features/jobs/pages/CompanyPostEditClient.tsx
+++ b/src/features/jobs/pages/CompanyPostEditClient.tsx
@@ -59,7 +59,7 @@ function CompanyPostEditClient({ postId }: CompanyPostEditClientProps) {
       queryClient.invalidateQueries({ queryKey: ['companyPosts'] });
       queryClient.invalidateQueries({ queryKey: ['companyPost', postId] });
       toast.success(t('updateSuccess'));
-      router.push('/company');
+      router.push('/company/dashboard');
     },
     onError: (error) => {
       logError(error, 'CompanyPostEditClient.updatePost');
@@ -74,7 +74,7 @@ function CompanyPostEditClient({ postId }: CompanyPostEditClientProps) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['companyPosts'] });
       toast.success(t('deleteSuccess'));
-      router.push('/company');
+      router.push('/company/dashboard');
     },
     onError: (error) => {
       logError(error, 'CompanyPostEditClient.deletePost');
@@ -141,7 +141,7 @@ function CompanyPostEditClient({ postId }: CompanyPostEditClientProps) {
           <div className="text-center">
             <p className="text-slate-500 text-body-2">{t('notFound')}</p>
             <button
-              onClick={() => router.push('/company')}
+              onClick={() => router.push('/company/dashboard')}
               className="mt-4 text-blue-600 hover:text-blue-700 text-body-3 font-medium cursor-pointer"
             >
               {t('backToDashboard')}

--- a/src/features/landing/components/sections/HeroSection.tsx
+++ b/src/features/landing/components/sections/HeroSection.tsx
@@ -25,7 +25,7 @@ export default function HeroSection() {
   const t = useTranslations('landing.hero');
   const { isAuthenticated, userType, isLoading: authLoading } = useAuth();
   const loggedIn = !authLoading && isAuthenticated;
-  const dashboardHref = userType === 'company' ? '/company' : userType === 'admin' ? '/admin' : '/user/profile';
+  const dashboardHref = userType === 'company' ? '/company/dashboard' : userType === 'admin' ? '/admin' : '/user/profile';
 
   return (
     <section className="bg-white min-h-[calc(100vh-65px)] sm:min-h-screen flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 py-16 sm:py-20">

--- a/src/shared/components/LanguageToggle.tsx
+++ b/src/shared/components/LanguageToggle.tsx
@@ -41,7 +41,7 @@ export function LanguageToggle({ className, variant = 'light' }: LanguageToggleP
           disabled={isPending}
           aria-label={lang === 'ko' ? '한국어로 변경' : 'Switch to English'}
           className={cn(
-            'px-2.5 py-0.5 rounded-full text-caption-2 font-semibold transition-colors cursor-pointer select-none uppercase',
+            'px-2 py-px rounded-full text-caption-3 font-semibold transition-colors cursor-pointer select-none uppercase',
             locale === lang ? activeCls : inactiveCls,
           )}
         >

--- a/src/shared/components/UserTypeToggle.tsx
+++ b/src/shared/components/UserTypeToggle.tsx
@@ -39,7 +39,7 @@ export function UserTypeToggle({ value, onChange, disabled, className }: UserTyp
             onClick={() => !disabled && onChange(optValue)}
             disabled={disabled}
             className={cn(
-              'relative flex items-center gap-1 px-2.5 py-0.5 rounded-full text-caption-2 font-semibold transition-colors duration-200 cursor-pointer select-none z-10',
+              'relative flex items-center gap-0.5 px-2 py-px rounded-full text-caption-3 font-semibold transition-colors duration-200 cursor-pointer select-none z-10',
               isActive ? 'text-white' : 'text-slate-500 hover:text-slate-700'
             )}
             aria-label={`${label} 모드로 전환`}
@@ -51,7 +51,7 @@ export function UserTypeToggle({ value, onChange, disabled, className }: UserTyp
                 transition={{ type: 'spring', stiffness: 400, damping: 30 }}
               />
             )}
-            <Icon size={10} className="relative z-10 shrink-0" />
+            <Icon size={9} className="relative z-10 shrink-0" />
             <span className="relative z-10">{label}</span>
           </button>
         );

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -32,7 +32,7 @@ export function Header({ type, viewType, onViewTypeChange, isAuthenticated, onLo
         ];
 
   const myHomeHref = isAuthenticated
-    ? type === 'homepage' ? '/user/profile' : '/company'
+    ? type === 'homepage' ? '/user/profile' : '/company/dashboard'
     : '/login-select';
 
   return (

--- a/src/shared/components/layout/MobileNav.tsx
+++ b/src/shared/components/layout/MobileNav.tsx
@@ -233,7 +233,7 @@ export function MobileNav({ items, type = 'homepage', isAuthenticated, onLogout,
                   {isAuthenticated ? (
                     <>
                       <Link
-                        href={type === 'homepage' ? '/user/profile' : '/company'}
+                        href={type === 'homepage' ? '/user/profile' : '/company/dashboard'}
                         onClick={close}
                         className="flex items-center justify-between px-3 py-3.5 rounded-lg hover:bg-slate-50 transition-colors group"
                       >


### PR DESCRIPTION
## 변경 요약

  ### 1. 기업 라우트 분리 (`/company` ↔ `/company/dashboard`)                                                                                           
  이전에는 `/company` 한 URL이 인증 상태에 따라 랜딩과 대시보드를 분기 렌더하고 있었음. 같은 URL에서 두 페이지가 보이는 구조라 SEO/공유링크/메타데이터
  일관성, 그리고 마케팅 페이지를 로그인 후에도 보여줄 방법이 없다는 한계가 있었음.                                                                      
                                                                                                                                                      
  - **`/company`** — 항상 `CompanyLandingPage` (공개 마케팅 페이지)                                                                                     
  - **`/company/dashboard`** — 신규, `CompanyProfileClient` (인증 보호)                                                                               
  - 로그인된 기업이 `/company` 방문 시 사이드바에 **"대시보드로 가기"** CTA 노출                                                                        
                                                                                                                                                        
  ### 2. 기업 로그인 리다이렉트 우선순위 정리                                                                                                           
  `BusinessLoginForm`에서:                                                                                                                              
  1. `?callbackUrl=...` (미들웨어 딥링크) — 안전한 상대경로면 우선                                                                                      
  2. 백엔드 `responseUrl` — 단, 제너릭 `/`는 무시                                                                                                       
  3. `/company/dashboard` — 기본값                                                                                                                      
                                                                                                                                                        
  기존엔 백엔드가 `/`를 반환하면 홈페이지로 가서 기업 사용자가 매번 추가 클릭이 필요했음.                                                               
                                                                                                                                                      
  ### 3. UI 픽스                                                                                                                                        
  - **헤더 토글** (`UserTypeToggle`, `LanguageToggle`): 헤더 높이 대비 시각적 무게가 컸던 문제 → padding/font/icon 사이즈 축소                        
  - **Post Job 버튼**: `tailwind-merge`가 `text-caption-2`와 `text-white`를 같은 그룹으로 분류해 흰색이 누락되던 이슈 → 클래스 순서 조정 + inline style 
  fallback (이미 `CompanyLandingPage`에서 동일 패턴으로 처리되어 있던 사례)                                                                             
                                                                                                                                                        
  ## 영향 범위                                                                                                                                          
  - 미들웨어 `getDashboardUrl('company')`: `/company` → `/company/dashboard`                                                                          
  - `/company` 진입은 인증 여부 무관하게 200 (랜딩)                                                                                                     
  - `/company/dashboard` 비인증 진입 시 `/company-login?callbackUrl=/company/dashboard`로 리다이렉트                                                    
  - 가입/공고 수정/프로필 저장 등 기존 "/company 복귀" 흐름 모두 `/company/dashboard`로 통일                                                            
  - `HeaderClient` 비로그인 토글 케이스(Personal→Company 전환)는 의도적으로 `/company`(랜딩) 유지                                                       
                                                                                                                                                        
  ## 백엔드                                                                                                                                             
  변경 없음. `responseUrl`이 `/company`를 반환해도 클라이언트 fallback이 흡수.                                                                          
                                                                                                                                                        
  ## 테스트 체크리스트
  - [ ] 비로그인으로 `/company` 진입 → 랜딩 노출                                                                                                        
  - [ ] 비로그인으로 `/company/dashboard` 직접 진입 → `/company-login?callbackUrl=/company/dashboard` 리다이렉트                                        
  - [ ] 로그인 성공 → `/company/dashboard` 진입                                                                                                         
  - [ ] 로그인 시 `?callbackUrl=/company/jobs` 같은 딥링크 존중                                                                                         
  - [ ] 로그인된 기업이 `/company` 진입 → 사이드바에 "대시보드로 가기" 버튼 노출                                                                        
  - [ ] 공고 수정/삭제, 프로필 저장 후 `/company/dashboard` 복귀                                                                                        
  - [ ] 권한 없는 사용자가 `/company/*` 접근 시 본인 대시보드(`/admin` 또는 `/user/profile`)로 리다이렉트                                               
  - [ ] 헤더 토글(개인/기업, KO/EN) 사이즈 축소 반영, 활성 상태 텍스트 흰색 정상                                                                        
  - [ ] 기업 대시보드 진행중 공고 섹션의 "Post Job" 버튼 텍스트 흰색                                                                                    
  - [ ] `npm run check-all` 통과 