### PR TITLE
refactor: 공통 Button·헤더 토글 사이즈 정리 + Daum 우편번호 CSP 차단 해결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -60,9 +60,9 @@ const nextConfig: NextConfig = {
             value: [
               "default-src 'self'",
               // Next.js 개발 모드 및 빌드 최적화를 위해 필요
-              "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://t1.daumcdn.net https://static.cloudflareinsights.com",
+              "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://t1.daumcdn.net https://*.daumcdn.net https://static.cloudflareinsights.com",
               // Tailwind CSS 및 인라인 스타일 허용
-              "style-src 'self' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline' https://*.daumcdn.net",
               // 이미지는 자체 도메인 + data URI + HTTPS
               "img-src 'self' data: https:",
               // 폰트는 자체 도메인만
@@ -70,9 +70,9 @@ const nextConfig: NextConfig = {
               // Service Worker 허용 (PWA)
               "worker-src 'self'",
 
-              `connect-src 'self' https://wik-dev.moon-core.com https://*.workinkorea.net https://t1.daumcdn.net https://static.cloudflareinsights.com`,
-              // iframe 허용 안 함 (frame-ancestors와 함께 사용)
-              "frame-src 'none'",
+              `connect-src 'self' https://wik-dev.moon-core.com https://*.workinkorea.net https://*.daum.net https://*.daumcdn.net https://static.cloudflareinsights.com`,
+              // Daum/Kakao 우편번호 팝업(postcode.map.daum.net iframe) 허용
+              "frame-src https://*.daum.net https://*.daumcdn.net",
               // 객체 임베드 차단
               "object-src 'none'",
               // 기본 URI 제한

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,6 @@ import { WebsiteSchema, OrganizationSchema } from "@/shared/components/seo/Struc
 import "./globals.css";
 import ReactQueryProvider from "@/shared/lib/providers/QueryProvider";
 import { Toaster } from 'sonner';
-import Script from 'next/script';
 import { BackToTop } from '@/shared/ui/BackToTop';
 import { InstallPrompt } from '@/features/pwa/ui/InstallPrompt';
 import { NextIntlClientProvider } from 'next-intl';
@@ -27,10 +26,6 @@ export default async function RootLayout({
       <head>
         <WebsiteSchema />
         <OrganizationSchema />
-        <Script
-          src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"
-          strategy="beforeInteractive"
-        />
       </head>
       <body suppressHydrationWarning={true}>
         <NextIntlClientProvider locale={locale} messages={messages}>

--- a/src/shared/components/LanguageToggle.tsx
+++ b/src/shared/components/LanguageToggle.tsx
@@ -41,7 +41,7 @@ export function LanguageToggle({ className, variant = 'light' }: LanguageToggleP
           disabled={isPending}
           aria-label={lang === 'ko' ? '한국어로 변경' : 'Switch to English'}
           className={cn(
-            'px-1.5 py-px rounded-full text-caption-3 leading-none font-semibold transition-colors cursor-pointer select-none uppercase',
+            'px-1.5 py-px rounded-full text-[10px] leading-none font-semibold transition-colors cursor-pointer select-none uppercase',
             locale === lang ? activeCls : inactiveCls,
           )}
         >

--- a/src/shared/components/LanguageToggle.tsx
+++ b/src/shared/components/LanguageToggle.tsx
@@ -33,7 +33,7 @@ export function LanguageToggle({ className, variant = 'light' }: LanguageToggleP
     : 'text-slate-500 hover:text-slate-700';
 
   return (
-    <div className={cn('flex items-center rounded-full border p-0.5 gap-0.5 overflow-hidden', containerCls, className)}>
+    <div className={cn('flex items-center rounded-full border p-px gap-px overflow-hidden', containerCls, className)}>
       {(['ko', 'en'] as const).map((lang) => (
         <button
           key={lang}
@@ -41,7 +41,7 @@ export function LanguageToggle({ className, variant = 'light' }: LanguageToggleP
           disabled={isPending}
           aria-label={lang === 'ko' ? '한국어로 변경' : 'Switch to English'}
           className={cn(
-            'px-2 py-px rounded-full text-caption-3 font-semibold transition-colors cursor-pointer select-none uppercase',
+            'px-1.5 py-px rounded-full text-caption-3 leading-none font-semibold transition-colors cursor-pointer select-none uppercase',
             locale === lang ? activeCls : inactiveCls,
           )}
         >

--- a/src/shared/components/LanguageToggle.tsx
+++ b/src/shared/components/LanguageToggle.tsx
@@ -33,7 +33,7 @@ export function LanguageToggle({ className, variant = 'light' }: LanguageToggleP
     : 'text-slate-500 hover:text-slate-700';
 
   return (
-    <div className={cn('flex items-center rounded-full border p-px gap-px overflow-hidden', containerCls, className)}>
+    <div className={cn('flex items-center rounded-full border p-0.5 gap-0.5 overflow-hidden', containerCls, className)}>
       {(['ko', 'en'] as const).map((lang) => (
         <button
           key={lang}
@@ -41,7 +41,7 @@ export function LanguageToggle({ className, variant = 'light' }: LanguageToggleP
           disabled={isPending}
           aria-label={lang === 'ko' ? '한국어로 변경' : 'Switch to English'}
           className={cn(
-            'px-1.5 py-px rounded-full text-[10px] leading-none font-semibold transition-colors cursor-pointer select-none uppercase',
+            'px-2.5 py-1 rounded-full text-caption-2 leading-none font-semibold transition-colors cursor-pointer select-none uppercase',
             locale === lang ? activeCls : inactiveCls,
           )}
         >

--- a/src/shared/components/UserTypeToggle.tsx
+++ b/src/shared/components/UserTypeToggle.tsx
@@ -39,7 +39,7 @@ export function UserTypeToggle({ value, onChange, disabled, className }: UserTyp
             onClick={() => !disabled && onChange(optValue)}
             disabled={disabled}
             className={cn(
-              'relative flex items-center gap-0.5 px-1.5 py-px rounded-full text-caption-3 leading-none font-semibold transition-colors duration-200 cursor-pointer select-none z-10',
+              'relative flex items-center gap-0.5 px-1.5 py-px rounded-full text-[10px] leading-none font-semibold transition-colors duration-200 cursor-pointer select-none z-10',
               isActive ? 'text-white' : 'text-slate-500 hover:text-slate-700'
             )}
             aria-label={`${label} 모드로 전환`}

--- a/src/shared/components/UserTypeToggle.tsx
+++ b/src/shared/components/UserTypeToggle.tsx
@@ -25,7 +25,7 @@ export function UserTypeToggle({ value, onChange, disabled, className }: UserTyp
   return (
     <div
       className={cn(
-        'relative flex items-center border border-slate-200 rounded-full bg-white p-0.5 gap-0.5',
+        'relative flex items-center border border-slate-200 rounded-full bg-white p-px gap-px',
         disabled && 'opacity-50 cursor-not-allowed',
         className
       )}
@@ -39,7 +39,7 @@ export function UserTypeToggle({ value, onChange, disabled, className }: UserTyp
             onClick={() => !disabled && onChange(optValue)}
             disabled={disabled}
             className={cn(
-              'relative flex items-center gap-0.5 px-2 py-px rounded-full text-caption-3 font-semibold transition-colors duration-200 cursor-pointer select-none z-10',
+              'relative flex items-center gap-0.5 px-1.5 py-px rounded-full text-caption-3 leading-none font-semibold transition-colors duration-200 cursor-pointer select-none z-10',
               isActive ? 'text-white' : 'text-slate-500 hover:text-slate-700'
             )}
             aria-label={`${label} 모드로 전환`}
@@ -51,7 +51,7 @@ export function UserTypeToggle({ value, onChange, disabled, className }: UserTyp
                 transition={{ type: 'spring', stiffness: 400, damping: 30 }}
               />
             )}
-            <Icon size={9} className="relative z-10 shrink-0" />
+            <Icon size={8} className="relative z-10 shrink-0" />
             <span className="relative z-10">{label}</span>
           </button>
         );

--- a/src/shared/components/UserTypeToggle.tsx
+++ b/src/shared/components/UserTypeToggle.tsx
@@ -25,7 +25,7 @@ export function UserTypeToggle({ value, onChange, disabled, className }: UserTyp
   return (
     <div
       className={cn(
-        'relative flex items-center border border-slate-200 rounded-full bg-white p-px gap-px',
+        'relative flex items-center border border-slate-200 rounded-full bg-white p-0.5 gap-0.5',
         disabled && 'opacity-50 cursor-not-allowed',
         className
       )}
@@ -39,7 +39,7 @@ export function UserTypeToggle({ value, onChange, disabled, className }: UserTyp
             onClick={() => !disabled && onChange(optValue)}
             disabled={disabled}
             className={cn(
-              'relative flex items-center gap-0.5 px-1.5 py-px rounded-full text-[10px] leading-none font-semibold transition-colors duration-200 cursor-pointer select-none z-10',
+              'relative flex items-center gap-1 px-2.5 py-1 rounded-full text-caption-2 leading-none font-semibold transition-colors duration-200 cursor-pointer select-none z-10',
               isActive ? 'text-white' : 'text-slate-500 hover:text-slate-700'
             )}
             aria-label={`${label} 모드로 전환`}
@@ -51,7 +51,7 @@ export function UserTypeToggle({ value, onChange, disabled, className }: UserTyp
                 transition={{ type: 'spring', stiffness: 400, damping: 30 }}
               />
             )}
-            <Icon size={8} className="relative z-10 shrink-0" />
+            <Icon size={11} className="relative z-10 shrink-0" />
             <span className="relative z-10">{label}</span>
           </button>
         );

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -25,10 +25,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           variant === 'outline'     && 'bg-white text-slate-600 border border-slate-200 hover:bg-slate-50',
           variant === 'ghost'       && 'bg-transparent text-slate-600 hover:bg-slate-100',
           variant === 'destructive' && 'bg-red-500 text-white hover:bg-red-600 active:bg-red-700',
-          size === 'sm' && 'px-3.5 py-1.5 text-caption-1',
-          size === 'md' && 'px-5 py-2.5 text-body-3',
-          size === 'lg' && 'px-7 py-3.5 text-body-2',
-          size === 'xl' && 'px-9 py-4 text-body-1',
+          size === 'sm' && 'px-3 py-1 text-caption-2',
+          size === 'md' && 'px-4 py-2 text-caption-1',
+          size === 'lg' && 'px-6 py-2.5 text-body-3',
+          size === 'xl' && 'px-8 py-3 text-body-2',
           className,
         )}
         style={mergedStyle}

--- a/src/shared/ui/DaumPostcodeSearch.tsx
+++ b/src/shared/ui/DaumPostcodeSearch.tsx
@@ -46,13 +46,13 @@ function DaumPostcodeSearch({
     setAddress(value);
   }, [value]);
 
-  const openPostcode = () => {
-    new window.daum!.Postcode({
-      oncomplete: function (data: DaumPostcodeData) {
-        // 도로명 주소 우선, 없으면 지번 주소 사용
-        const fullAddress = data.roadAddress || data.jibunAddress;
+  const SCRIPT_SRC = 'https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
 
-        // 건물명이 있는 경우 추가
+  const openPostcode = () => {
+    if (!window.daum?.Postcode) return;
+    new window.daum.Postcode({
+      oncomplete: function (data: DaumPostcodeData) {
+        const fullAddress = data.roadAddress || data.jibunAddress;
         const extraAddress = data.buildingName ? ` (${data.buildingName})` : '';
         const finalAddress = fullAddress + extraAddress;
 
@@ -64,31 +64,37 @@ function DaumPostcodeSearch({
     }).open();
   };
 
-  const handleSearchClick = () => {
+  const waitForDaum = (script: HTMLScriptElement) =>
+    new Promise<void>((resolve, reject) => {
+      if (window.daum?.Postcode) return resolve();
+      const onLoad = () => {
+        if (window.daum?.Postcode) resolve();
+        else reject(new Error('Daum Postcode SDK loaded but namespace missing'));
+      };
+      script.addEventListener('load', onLoad, { once: true });
+      script.addEventListener('error', () => reject(new Error('Daum Postcode SDK load failed')), { once: true });
+    });
+
+  const handleSearchClick = async () => {
     if (window.daum?.Postcode) {
       openPostcode();
       return;
     }
 
-    // 스크립트가 아직 로드되지 않았다면 동적으로 로드 후 재시도
-    const SCRIPT_SRC = 'https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
-    const existing = document.querySelector<HTMLScriptElement>(`script[src="${SCRIPT_SRC}"]`);
-
-    if (existing) {
-      existing.addEventListener('load', openPostcode, { once: true });
-      return;
+    let script = document.querySelector<HTMLScriptElement>(`script[src="${SCRIPT_SRC}"]`);
+    if (!script) {
+      script = document.createElement('script');
+      script.src = SCRIPT_SRC;
+      script.async = true;
+      document.head.appendChild(script);
     }
 
-    const script = document.createElement('script');
-    script.src = SCRIPT_SRC;
-    script.async = true;
-    script.onload = () => {
-      if (window.daum?.Postcode) openPostcode();
-    };
-    script.onerror = () => {
+    try {
+      await waitForDaum(script);
+      openPostcode();
+    } catch {
       alert('주소 검색 서비스를 불러오지 못했습니다. 네트워크 연결을 확인해주세요.');
-    };
-    document.head.appendChild(script);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary

  - **Button 컴포넌트 사이즈 한 단계 축소** — sm/md/lg/xl 모두 폰트·패딩을 한 단계씩 다운(예: xl `text-body-1`(16px) → `text-body-2`(15px), `py-4` →    
  `py-3`)
  - **헤더 토글(언어/사용자 타입) 사이즈 정리** — 폰트 `text-caption-2`(12px) + `leading-none`, 패딩 `px-2.5 py-1`, 컨테이너 `p-0.5 gap-0.5`로 균형     
  재조정. UserTypeToggle 아이콘 `size={11}`                                                                                                             
  - **Daum/Kakao 우편번호 팝업 차단 fix** — CSP `frame-src 'none'`이 `postcode.map.daum.net` iframe을 차단해 about:blank로 표시되던 문제 해결.
  `*.daum.net` / `*.daumcdn.net`을 frame-src·connect-src·script-src·style-src에 허용                                                                    
  - **DaumPostcodeSearch 로딩 일원화** — 레이아웃의 `beforeInteractive` 중복 스크립트 제거, 컴포넌트의 lazy 로더로 통일. `window.daum!` non-null 단정 
  제거 후 Promise 기반 load/error race로 정리                                                                                                           
                                                                                                                                                      
  ## Changes                                                                                                                                            
                                                                                                                                                      
  | 영역 | 파일 |
  |------|------|
  | Button | `src/shared/ui/Button.tsx` |
  | Toggle | `src/shared/components/{LanguageToggle,UserTypeToggle}.tsx` |                                                                              
  | Postcode | `src/shared/ui/DaumPostcodeSearch.tsx`, `src/app/layout.tsx` |                                                                           
  | Security | `next.config.ts` (CSP) |                                                                                                                 
                                                                                                                                                        
  ## Test plan                                                                                                                                          
                                                                                                                                                        
  - [ ] `npm run typecheck` 통과 확인                                                                                                                 
  - [ ] 로컬에서 헤더의 KO/EN, 개인/기업 토글이 균형있게 보이는지 (12px / py-1)
  - [ ] Button 모든 사이즈(sm/md/lg/xl)가 페이지 전반에서 깨지지 않는지 (랜딩, 공고, 프로필)                                                            
  - [ ] 배포 환경에서 `/company/posts/create` 주소검색 클릭 시 Daum 팝업 정상 렌더 (about:blank 미표시)                                                 
  - [ ] CSP 헤더 변경 후 다른 외부 리소스 로딩에 회귀 없는지 (Cloudflare Insights 포함)                                                                 
                                                                                                                                                        
  ## Notes                                                                                                                                              
                                                                                                                                                        
  - CSP의 `frame-src` 정책이 `'none'` → `https://*.daum.net https://*.daumcdn.net`으로 완화됩니다. 보안 영향 범위는 우편번호 서비스 도메인에 한정.      
  - 토글 폰트는 canonical 토큰(`text-caption-2`)을 유지했습니다.